### PR TITLE
fix(middleware): use appropriate encryption and decryption for middleware

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -36,8 +36,13 @@ where
     D: serde::Deserializer<'de>,
 {
     let deserialized_str: String = serde::Deserialize::deserialize(deserializer)?;
+    #[cfg(not(feature = "kms"))]
+    let deserialized_str = hex::decode(deserialized_str)
+        .map_err(|_| serde::de::Error::custom("error while parsing hex"))?;
+    #[cfg(feature = "kms")]
+    let deserialized_str = deserialized_str.into_bytes();
 
-    Ok(deserialized_str.into_bytes())
+    Ok(deserialized_str)
 }
 
 /// Get the origin directory of the project

--- a/src/crypto/jw.rs
+++ b/src/crypto/jw.rs
@@ -2,8 +2,8 @@ use crate::error;
 use josekit::{jwe, jws};
 
 pub struct JWEncryption {
-    private_key: String,
-    public_key: String,
+    pub(crate) private_key: String,
+    pub(crate) public_key: String,
 }
 
 #[derive(Debug, Clone, serde::Serialize, serde::Deserialize)]
@@ -14,7 +14,7 @@ pub struct JwsBody {
 }
 
 impl JwsBody {
-    fn from_str(input: &str) -> Option<Self> {
+    fn from_dotted_str(input: &str) -> Option<Self> {
         let mut data = input.split('.');
         let header = data.next()?.to_string();
         let payload = data.next()?.to_string();
@@ -77,7 +77,7 @@ impl super::Encryption<Vec<u8>, Vec<u8>> for JWEncryption {
     fn encrypt(&self, input: Vec<u8>) -> Self::ReturnType<'_, Vec<u8>> {
         let payload = input;
         let jws_encoded = jws_sign_payload(&payload, self.private_key.as_bytes())?;
-        let jws_body = JwsBody::from_str(&jws_encoded).ok_or(error::CryptoError::InvalidData(
+        let jws_body = JwsBody::from_dotted_str(&jws_encoded).ok_or(error::CryptoError::InvalidData(
             "JWS encoded data is incomplete",
         ))?;
         let jws_payload = serde_json::to_vec(&jws_body)?;
@@ -90,11 +90,11 @@ impl super::Encryption<Vec<u8>, Vec<u8>> for JWEncryption {
     fn decrypt(&self, input: Vec<u8>) -> Self::ReturnType<'_, Vec<u8>> {
         let jwe_body: JweBody = serde_json::from_slice(&input)?;
         let jwe_encoded = jwe_body.get_dotted_jwe();
-        let algo = jwe::RSA_OAEP;
+        let algo = jwe::RSA_OAEP_256;
         let jwe_decrypted = decrypt_jwe(&jwe_encoded, self.private_key.clone(), algo)?;
-        let jws_parsed = JwsBody::from_str(&jwe_decrypted).ok_or(
-            error::CryptoError::InvalidData("Failed while extracting jws body"),
-        )?;
+
+        let jws_parsed: JwsBody = serde_json::from_str(&jwe_decrypted).map_err(|_| error::CryptoError::InvalidData("Failed while extracting jws body"))?;
+
         let jws_encoded = jws_parsed.get_dotted_jws();
         let output = verify_sign(jws_encoded, self.public_key.clone())?;
         Ok(output.as_bytes().to_vec())
@@ -115,7 +115,7 @@ pub fn encrypt_jwe(
     payload: &[u8],
     public_key: impl AsRef<[u8]>,
 ) -> Result<String, error::CryptoError> {
-    let alg = jwe::RSA_OAEP_256;
+    let alg = jwe::RSA_OAEP;
     let enc = "A256GCM";
     let mut src_header = jwe::JweHeader::new();
     src_header.set_content_encryption(enc);

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -1,6 +1,6 @@
 use axum::{
     extract,
-    routing::{get, post},
+    routing::post,
     Json,
 };
 
@@ -30,7 +30,7 @@ pub fn serve(#[cfg(feature = "middleware")] state: AppState) -> axum::Router<App
     let router = axum::Router::new()
         .route("/add", post(add_card))
         .route("/delete", post(delete_card))
-        .route("/retrieve", get(retrieve_card));
+        .route("/retrieve", post(retrieve_card));
 
     #[cfg(feature = "middleware")]
     {

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -1,5 +1,4 @@
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Dedup {
     hash1: Option<String>,
     hash2: Option<String>,
@@ -7,8 +6,7 @@ pub struct Dedup {
     hash2_reference: Option<String>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Card {
     card_number: masking::Secret<String>,
     name_on_card: Option<String>,
@@ -20,7 +18,6 @@ pub struct Card {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct StoreCardRespPayload {
     pub card_reference: String,
     pub dedup: Option<DedupResponsePayload>,
@@ -35,8 +32,7 @@ pub struct DedupResponsePayload {
 // Create Card Data Structures
 
 // prioritizing card data over enc_card_data
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct StoreCardRequest {
     pub merchant_id: String,
     pub merchant_customer_id: String,
@@ -48,8 +44,7 @@ pub struct StoreCardRequest {
     pub dedup: Option<Dedup>,
 }
 
-#[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
+#[derive(serde::Serialize, serde::Deserialize, Debug)]
 #[serde(untagged)]
 pub enum Data {
     Card { card: Card },
@@ -57,7 +52,6 @@ pub enum Data {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct StoreCardResponse {
     pub status: String,
     pub error_message: Option<String>,
@@ -68,7 +62,6 @@ pub struct StoreCardResponse {
 // Retrieve Card Data Structures
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct RetrieveCardRequest {
     pub merchant_id: String,
     pub merchant_customer_id: String,
@@ -76,7 +69,6 @@ pub struct RetrieveCardRequest {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct RetrieveCardResponse {
     pub status: String,
     pub error_message: Option<String>,
@@ -85,14 +77,12 @@ pub struct RetrieveCardResponse {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct RetrieveCardRespPayload {
     pub card: Option<Card>,
     pub enc_card_data: Option<String>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct DeleteCardRequest {
     pub merchant_id: String,
     pub merchant_customer_id: String,
@@ -100,7 +90,6 @@ pub struct DeleteCardRequest {
 }
 
 #[derive(serde::Serialize, serde::Deserialize)]
-#[serde(rename_all = "camelCase")]
 pub struct DeleteCardResponse {
     pub status: String,
     pub error_message: Option<String>,

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -40,4 +40,8 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(hash_table, locker, merchant,);
+diesel::allow_tables_to_appear_in_same_query!(
+    hash_table,
+    locker,
+    merchant,
+);


### PR DESCRIPTION
This pr is to use appropriate encryption and decryption for middleware and also remove rename the structs in type.rs to camelCase.

-> I have tested it through postman
Create customer
![image](https://github.com/NishantJoshi00/tartarus/assets/83439957/536b4b82-4f24-4da0-8497-6163da50e8d7)
PaymentMethod create
![image](https://github.com/NishantJoshi00/tartarus/assets/83439957/bf3f0969-07d9-4080-9bbf-a9be0d350350)
List payment methods for a customer
![image](https://github.com/NishantJoshi00/tartarus/assets/83439957/1eb8697a-42f1-4c11-a669-42749f422926)
