### PR TITLE
bump(tartarus): bump the crate version to 0.1.2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "tartarus"
-version = "0.1.0"
+version = "0.1.2"
 edition = "2021"
 default-run = "locker"
 


### PR DESCRIPTION
The changes that are included in this release are as follows:
- New revamped error framework
- Key and card validation
- limiting for delete API