### PR TITLE
feat(router): use only card number for card duplication check

### DIFF
--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -10,7 +10,7 @@ use masking::ExposeInterface;
 
 use crate::{
     app::AppState,
-    crypto::{aes::GcmAes256, sha::Sha512, Encode},
+    crypto::{aes::GcmAes256, sha::Sha512},
     error::{self, ContainerError, ResultContainerExt},
     storage::{HashInterface, LockerInterface, MerchantInterface},
 };
@@ -86,27 +86,12 @@ pub async fn add_card(
             &master_encryption,
         )
         .await?;
-    // .change_context(error::ApiError::RetrieveDataFailed("merchant"))
 
     let merchant_dek = GcmAes256::new(merchant.enc_key.expose());
-
-    // let hash_data = serde_json::to_vec(&request.data)
-    //     .change_error(error::ApiError::EncodingError)
-    //     .and_then(|data| Ok((Sha512).encode(data)?))?;
-
-    // let data = match &request.data {
-    //     types::Data::EncData { enc_card_data } => enc_card_data,
-    //     types::Data::Card { card } => card.card_number.peek(),
-    // };
-
-    // let hash_data = serde_json::to_vec(&data)
-    //     .change_error(error::ApiError::EncodingError)
-    //     .and_then(|data| Ok((Sha512).encode(data)?))?;
 
     let hash_data = transformers::get_hash(&request.data, Sha512)
         .change_error(error::ApiError::EncodingError)?;
 
-    //card number duplication check
     let optional_hash_table = state.db.find_by_data_hash(&hash_data).await?;
 
     let output = match optional_hash_table {

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -90,10 +90,23 @@ pub async fn add_card(
 
     let merchant_dek = GcmAes256::new(merchant.enc_key.expose());
 
-    let hash_data = serde_json::to_vec(&request.data)
-        .change_error(error::ApiError::EncodingError)
-        .and_then(|data| Ok((Sha512).encode(data)?))?;
+    // let hash_data = serde_json::to_vec(&request.data)
+    //     .change_error(error::ApiError::EncodingError)
+    //     .and_then(|data| Ok((Sha512).encode(data)?))?;
 
+    // let data = match &request.data {
+    //     types::Data::EncData { enc_card_data } => enc_card_data,
+    //     types::Data::Card { card } => card.card_number.peek(),
+    // };
+
+    // let hash_data = serde_json::to_vec(&data)
+    //     .change_error(error::ApiError::EncodingError)
+    //     .and_then(|data| Ok((Sha512).encode(data)?))?;
+
+    let hash_data = transformers::get_hash(&request.data, Sha512)
+        .change_error(error::ApiError::EncodingError)?;
+
+    //card number duplication check
     let optional_hash_table = state.db.find_by_data_hash(&hash_data).await?;
 
     let output = match optional_hash_table {

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -13,7 +13,7 @@ use crate::error;
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
 pub struct Card {
-    card_number: masking::StrongSecret<String>,
+    pub card_number: masking::StrongSecret<String>,
     name_on_card: Option<String>,
     card_exp_month: Option<String>,
     card_exp_year: Option<String>,


### PR DESCRIPTION
Currently we are taking the hash of entire card details (payment method data) for card duplication check. In this case if a add card request is made for same card number but with a different card holder name, cvv or expiry it would pass the card duplication check and the card would get added even though the card number is same. 
So this pr treats the card number as a unique field and performs the duplication based on it.

Test case :-
1) Payment method create.
<img width="1103" alt="image" src="https://github.com/juspay/hyperswitch-card-vault/assets/83439957/ebf7688b-1a16-43f2-94d5-1180b070949b">
2) Payment method create for same merchant and customer, change `card_holder_name` keeping the the card number same.

![image](https://github.com/juspay/hyperswitch-card-vault/assets/83439957/45c3a71e-e990-4de5-8863-ff512251d174)
3) Locker db still has only one card inserted in locker table.
![image](https://github.com/juspay/hyperswitch-card-vault/assets/83439957/0e304150-6e1b-4bd1-a7fa-5ec05adb95d6)
4) Also there is only one entry in the hash table as well.
![image](https://github.com/juspay/hyperswitch-card-vault/assets/83439957/bc97fd00-3284-40ec-a542-90062c39bd20)