### PR TITLE
chore: fix caching issue for conditional merchant creation

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -59,6 +59,8 @@ pub enum StorageError {
     DecryptionError,
     #[error("Error while encrypting the payload")]
     EncryptionError,
+    #[error("Element not found in storage")]
+    NotFoundError,
 }
 
 #[derive(Debug, Copy, Clone, thiserror::Error)]

--- a/src/error/container.rs
+++ b/src/error/container.rs
@@ -1,7 +1,7 @@
 use std::error::Error;
 
 pub struct ContainerError<E> {
-    pub(super) error: error_stack::Report<E>,
+    pub(crate) error: error_stack::Report<E>,
 }
 
 impl<T> std::fmt::Debug for ContainerError<T> {

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -10,6 +10,8 @@ pub enum MerchantDBError {
     DBFilterError,
     #[error("Error while inserting element in the database")]
     DBInsertError,
+    #[error("Element not found in database")]
+    NotFoundError,
     #[error("Unpredictable error occurred")]
     UnknownError,
 }
@@ -42,4 +44,14 @@ pub enum HashDBError {
     DBInsertError,
     #[error("Unpredictable error occurred")]
     UnknownError,
+}
+
+pub trait NotFoundError {
+    fn is_not_found(&self) -> bool;
+}
+
+impl NotFoundError for super::ContainerError<MerchantDBError> {
+    fn is_not_found(&self) -> bool {
+        matches!(self.error.current_context(), MerchantDBError::NotFoundError)
+    }
 }

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -40,6 +40,7 @@ impl<'a> From<&'a super::StorageError> for super::MerchantDBError {
             | super::StorageError::EncryptionError
             | super::StorageError::DeleteError => Self::UnknownError,
             super::StorageError::InsertError => Self::DBInsertError,
+            super::StorageError::NotFoundError => Self::NotFoundError,
         }
     }
 }
@@ -57,6 +58,7 @@ impl<'a> From<&'a super::StorageError> for super::LockerDBError {
             }
             super::StorageError::InsertError => Self::DBInsertError,
             super::StorageError::DeleteError => Self::DBDeleteError,
+            super::StorageError::NotFoundError => Self::DBFilterError,
         }
     }
 }
@@ -73,6 +75,7 @@ impl<'a> From<&'a super::StorageError> for super::HashDBError {
             | super::StorageError::EncryptionError
             | super::StorageError::DeleteError => Self::UnknownError,
             super::StorageError::InsertError => Self::DBInsertError,
+            super::StorageError::NotFoundError => Self::DBFilterError,
         }
     }
 }
@@ -103,6 +106,7 @@ impl<'a> From<&'a super::MerchantDBError> for super::ApiError {
                                                          // occur because of master key failure
             super::MerchantDBError::DBError |
             super::MerchantDBError::DBFilterError |
+            super::MerchantDBError::NotFoundError |
             super::MerchantDBError::DBInsertError=> Self::MerchantError,
             super::MerchantDBError::UnknownError => Self::UnknownError
         }

--- a/src/storage/caching/hash_table.rs
+++ b/src/storage/caching/hash_table.rs
@@ -38,3 +38,42 @@ where
         Ok(output)
     }
 }
+
+#[async_trait::async_trait]
+impl<T> storage::MerchantInterface for super::Caching<T, types::HashTable>
+where
+    T: storage::MerchantInterface + storage::Cacheable<types::HashTable> + Sync,
+{
+    type Algorithm = T::Algorithm;
+    type Error = T::Error;
+
+    async fn find_by_merchant_id(
+        &self,
+        merchant_id: &str,
+        tenant_id: &str,
+        key: &Self::Algorithm,
+    ) -> Result<types::Merchant, ContainerError<Self::Error>> {
+        self.inner
+            .find_by_merchant_id(merchant_id, tenant_id, key)
+            .await
+    }
+
+    async fn find_or_create_by_merchant_id(
+        &self,
+        merchant_id: &str,
+        tenant_id: &str,
+        key: &Self::Algorithm,
+    ) -> Result<types::Merchant, ContainerError<Self::Error>> {
+        self.inner
+            .find_or_create_by_merchant_id(merchant_id, tenant_id, key)
+            .await
+    }
+
+    async fn insert_merchant(
+        &self,
+        new: types::MerchantNew<'_>,
+        key: &Self::Algorithm,
+    ) -> Result<types::Merchant, ContainerError<Self::Error>> {
+        self.inner.insert_merchant(new, key).await
+    }
+}


### PR DESCRIPTION
## Description

There is an issue with the consistency of nested types for caching, the issue lies in the way `Deref` works and how the traits are implemented.

example:
```rust
struct A;
struct B;
struct C;

trait MyTrait {}

impl MyTrait for C {}

impl Deref for A {
	type Target = B;
}
impl Deref for B {
	type Target = C;
}

fn handle<X, Y>(data: X)
where
	X: Deref<Target = Y>,
	Y: MyTrait
{}
```
In this scenerio struct of type `B` can be passed to the function `handle` without any issue, but when trying to pass `A` you will get an error:
```
error[E0277]: the trait bound `B: MyTrait` is not satisfied
   --> src/main.rs:112:5
    |
112 |     handle(A);
    |     ^^^^^^ the trait `MyTrait` is not implemented for `B`
    |
    = help: the trait `MyTrait` is implemented for `C`
note: required by a bound in `handle`
   --> src/main.rs:108:5
    |
105 | fn handle<X, Y>(_data: X)
    |    ------ required by a bound in this function
...
108 |     Y: MyTrait
    |        ^^^^^^^ required by this bound in `handle`
```

---

This example describes the situation with caching, where as the intermediate layers are only implementing `Deref` for the internal Storage, and does not auto implement the traits that are implemented on Storage. This issue will be mitigated once rust stabalizes `specialization`.

Tracking issue for `specialization`: https://github.com/rust-lang/rust/issues/31844

