### PR TITLE
build: obtain workspace member package names from cargo_metadata more deterministically

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -642,9 +642,9 @@ dependencies = [
 
 [[package]]
 name = "cargo_metadata"
-version = "0.15.4"
+version = "0.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eee4243f1f26fc7a42710e7439c149e2b10b05472f88090acce52632f231a73a"
+checksum = "2d886547e41f740c616ae73108f6eb70afe6d940c7bc697cb30f13daec073037"
 dependencies = [
  "camino",
  "cargo-platform",
@@ -2879,7 +2879,7 @@ dependencies = [
  "axum",
  "axum-test",
  "base64 0.21.7",
- "cargo_metadata 0.15.4",
+ "cargo_metadata 0.18.1",
  "config",
  "criterion",
  "diesel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -73,7 +73,7 @@ criterion = "0.5.1"
 axum-test = "14.2.2"
 
 [build-dependencies]
-cargo_metadata = "0.15.4"
+cargo_metadata = "0.18.1"
 
 
 [[bin]]

--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,5 @@
 mod cargo_workspace {
-    /// Verify that the cargo metadata workspace members format matches that expected by
+    /// Verify that the cargo metadata workspace packages format matches that expected by
     /// [`set_cargo_workspace_members_env`] to set the `CARGO_WORKSPACE_MEMBERS` environment variable.
     ///
     /// This function should be typically called within build scripts, before the
@@ -7,24 +7,20 @@ mod cargo_workspace {
     ///
     /// # Panics
     ///
-    /// Panics if running the `cargo metadata` command fails, or if the workspace members package ID
-    /// format cannot be determined.
+    /// Panics if running the `cargo metadata` command fails, or if the workspace member package names
+    /// cannot be determined.
     pub fn verify_cargo_metadata_format() {
         #[allow(clippy::expect_used)]
         let metadata = cargo_metadata::MetadataCommand::new()
             .exec()
             .expect("Failed to obtain cargo metadata");
-        let workspace_members = metadata.workspace_members;
 
-        let package_id_entry_prefix =
-            format!("{} {}", env!("CARGO_PKG_NAME"), env!("CARGO_PKG_VERSION"));
         assert!(
-            workspace_members
+            metadata
+                .workspace_packages()
                 .iter()
-                .any(|package_id| package_id.repr.starts_with(&package_id_entry_prefix)),
-            "Unknown workspace members package ID format. \
-         Please run `cargo metadata --format-version=1 | jq '.workspace_members'` and update this \
-         build script to match the updated package ID format."
+                .any(|package| package.name == env!("CARGO_PKG_NAME")),
+            "Unable to determine workspace member package names from `cargo metadata`"
         );
     }
 
@@ -44,17 +40,11 @@ mod cargo_workspace {
         let metadata = cargo_metadata::MetadataCommand::new()
             .exec()
             .expect("Failed to obtain cargo metadata");
-        let workspace_members = metadata.workspace_members;
 
-        let workspace_members = workspace_members
+        let workspace_members = metadata
+            .workspace_packages()
             .iter()
-            .map(|package_id| {
-                package_id
-                    .repr
-                    .split_once(' ')
-                    .expect("Unknown cargo metadata package ID format")
-                    .0
-            })
+            .map(|package| package.name.as_str())
             .collect::<Vec<_>>()
             .join(",");
 


### PR DESCRIPTION
This PR updates the build script code to obtain cargo workspace member package names to use a better and more deterministic way to do so. 

Previously, we used to perform string manipulation on the package ID format (obtained from the `workspace_members` field in `cargo metadata --format-version=1`), and the package ID format was not stabilized (until recently). The package ID format has been [stabilized](https://github.com/rust-lang/cargo/pull/12914) in Rust 1.77, and the stabilized format breaks our existing build scripts. This PR updates the build script code to instead obtain the workspace member package names using the [`Metadata::workspace_packages()`](https://docs.rs/cargo_metadata/0.18.1/cargo_metadata/struct.Metadata.html#method.workspace_packages) method that the `cargo_metadata` crate provides.