### PR TITLE
refactor(ttl): add support for accepting ttl in seconds as opposed to datetime

### DIFF
--- a/docs/openapi/spec.yml
+++ b/docs/openapi/spec.yml
@@ -204,6 +204,10 @@ components:
         enc_card_data:
           type: string
           example: "qwe4tyusdfg"
+        ttl:
+          type: "integer"
+          example: 60
+
     RetrieveDataReq:
       type: object
       properties:

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -34,7 +34,7 @@ impl<'a> TryFrom<(super::types::StoreCardRequest, &'a str, &'a str)>
             customer_id: value.merchant_customer_id,
             enc_data: data.into(),
             hash_id,
-            ttl: value.ttl,
+            ttl: *value.ttl,
         })
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -2,59 +2,6 @@
 pub mod date_time {
     use time::{OffsetDateTime, PrimitiveDateTime};
 
-    /// Use the well-known ISO 8601 format when serializing and deserializing an
-    /// [`Option<PrimitiveDateTime>`][PrimitiveDateTime].
-    /// Example: `2024-04-16T17:35:00.000Z`
-    ///
-    /// [PrimitiveDateTime]: ::time::PrimitiveDateTime
-    pub mod optional_iso8601 {
-        use std::num::NonZeroU8;
-
-        use serde::{ser::Error as _, Deserializer, Serialize, Serializer};
-        use time::{
-            format_description::well_known::{
-                iso8601::{Config, EncodedConfig, TimePrecision},
-                Iso8601,
-            },
-            serde::iso8601,
-            PrimitiveDateTime, UtcOffset,
-        };
-
-        const FORMAT_CONFIG: EncodedConfig = Config::DEFAULT
-            .set_time_precision(TimePrecision::Second {
-                decimal_digits: NonZeroU8::new(3),
-            })
-            .encode();
-
-        /// Serialize an [`Option<PrimitiveDateTime>`] using the well-known ISO 8601 format.
-        pub fn serialize<S>(
-            date_time: &Option<PrimitiveDateTime>,
-            serializer: S,
-        ) -> Result<S::Ok, S::Error>
-        where
-            S: Serializer,
-        {
-            date_time
-                .map(|date_time| date_time.assume_utc().format(&Iso8601::<FORMAT_CONFIG>))
-                .transpose()
-                .map_err(S::Error::custom)?
-                .serialize(serializer)
-        }
-
-        /// Deserialize an [`Option<PrimitiveDateTime>`] from its ISO 8601 representation.
-        pub fn deserialize<'a, D>(deserializer: D) -> Result<Option<PrimitiveDateTime>, D::Error>
-        where
-            D: Deserializer<'a>,
-        {
-            iso8601::option::deserialize(deserializer).map(|option_offset_date_time| {
-                option_offset_date_time.map(|offset_date_time| {
-                    let utc_date_time = offset_date_time.to_offset(UtcOffset::UTC);
-                    PrimitiveDateTime::new(utc_date_time.date(), utc_date_time.time())
-                })
-            })
-        }
-    }
-
     /// Create a new [`PrimitiveDateTime`] with the current date and time in UTC.
     pub fn now() -> PrimitiveDateTime {
         let utc_date_time = OffsetDateTime::now_utc();


### PR DESCRIPTION
This PR adds support for accepting the ttl during store card request in seconds as opposed to iso datetime.