### PR TITLE
fix: address non-digit character cases in card number validation

### DIFF
--- a/benches/luhn-test.rs
+++ b/benches/luhn-test.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use std::fmt::Write;
-use tartarus::validations::luhn_on_string;
+use tartarus::validations::validate_card_number;
 
 #[allow(clippy::expect_used)]
 fn card_number_generator() -> String {
@@ -16,11 +16,11 @@ pub fn criterion_luhn(c: &mut Criterion) {
         b.iter(|| black_box(card_number_generator()))
     });
     c.bench_function("luhn-validation", |b| {
-        b.iter(|| black_box(luhn_on_string(&black_box(card_number_generator()))))
+        b.iter(|| black_box(validate_card_number(&black_box(card_number_generator()))))
     });
     let card_number = card_number_generator();
     c.bench_function("luhn", |b| {
-        b.iter(|| black_box(luhn_on_string(black_box(&card_number))))
+        b.iter(|| black_box(validate_card_number(black_box(&card_number))))
     });
 }
 

--- a/benches/luhn-test.rs
+++ b/benches/luhn-test.rs
@@ -1,12 +1,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use std::fmt::Write;
-use tartarus::validations::validate_card_number;
+use tartarus::validations::{luhn, MAX_CARD_NUMBER_LENGTH};
 
 #[allow(clippy::expect_used)]
-fn card_number_generator() -> String {
-    (0..16).fold(String::new(), |mut acc, _| {
-        write!(&mut acc, "{}", rand::random::<u8>() % 10)
-            .expect("Failed to write to string buffer");
+fn card_number_generator() -> Vec<u8> {
+    (0..16).fold(Vec::with_capacity(MAX_CARD_NUMBER_LENGTH), |mut acc, _| {
+        acc.push(rand::random::<u8>() % 10);
         acc
     })
 }
@@ -16,11 +14,11 @@ pub fn criterion_luhn(c: &mut Criterion) {
         b.iter(|| black_box(card_number_generator()))
     });
     c.bench_function("luhn-validation", |b| {
-        b.iter(|| black_box(validate_card_number(&black_box(card_number_generator()))))
+        b.iter(|| black_box(luhn(&black_box(card_number_generator()))))
     });
     let card_number = card_number_generator();
     c.bench_function("luhn", |b| {
-        b.iter(|| black_box(validate_card_number(black_box(&card_number))))
+        b.iter(|| black_box(luhn(black_box(&card_number))))
     });
 }
 

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -154,7 +154,7 @@ impl Validation for StoreCardRequest {
 
         match &self.data {
             Data::EncData { .. } => Ok(()),
-            Data::Card { card } => crate::validations::luhn_on_string(card.card_number.peek())
+            Data::Card { card } => crate::validations::luhn_on_string(card.card_number.peek())?
                 .then_some(())
                 .ok_or(error::ApiError::ValidationError("card number invalid")),
         }

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -7,13 +7,13 @@
 //     hash2_reference: Option<String>,
 // }
 
-use masking::{PeekInterface, Secret};
+use masking::Secret;
 
 use crate::{error, storage, utils};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq)]
 pub struct Card {
-    pub card_number: masking::StrongSecret<String>,
+    pub card_number: storage::types::CardNumber,
     name_on_card: Option<String>,
     card_exp_month: Option<String>,
     card_exp_year: Option<String>,
@@ -154,9 +154,7 @@ impl Validation for StoreCardRequest {
 
         match &self.data {
             Data::EncData { .. } => Ok(()),
-            Data::Card { card } => crate::validations::luhn_on_string(card.card_number.peek())?
-                .then_some(())
-                .ok_or(error::ApiError::ValidationError("card number invalid")),
+            Data::Card { card } => card.card_number.validate(),
         }
     }
 }

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -13,6 +13,7 @@ pub(crate) async fn health<Base: HealthCheck<State = State>, State>(
 pub(crate) trait HealthCheck {
     type State;
     async fn health(state: Self::State) -> (hyper::StatusCode, &'static str);
+    #[allow(dead_code)]
     async fn diagnostics(state: Self::State) -> (hyper::StatusCode, axum::Json<Diagnostics>);
 }
 

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -120,7 +120,7 @@ impl Validation for CardNumber {
     type Error = error::ApiError;
 
     fn validate(&self) -> Result<(), Self::Error> {
-        crate::validations::luhn_on_string(self.0.peek())
+        crate::validations::luhn_on_string(self.0.peek())?
             .then_some(())
             .ok_or(error::ApiError::ValidationError("card number invalid"))
     }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -120,7 +120,7 @@ impl Validation for CardNumber {
     type Error = error::ApiError;
 
     fn validate(&self) -> Result<(), Self::Error> {
-        crate::validations::validate_card_number(self.0.peek())?
+        crate::validations::sanitize_card_number(self.0.peek())?
             .then_some(())
             .ok_or(error::ApiError::ValidationError("card number invalid"))
     }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -120,7 +120,7 @@ impl Validation for CardNumber {
     type Error = error::ApiError;
 
     fn validate(&self) -> Result<(), Self::Error> {
-        crate::validations::luhn_on_string(self.0.peek())?
+        crate::validations::validate_card_number(self.0.peek())?
             .then_some(())
             .ok_or(error::ApiError::ValidationError("card number invalid"))
     }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -4,7 +4,7 @@ use diesel::{
     serialize::ToSql,
     sql_types, AsExpression, Identifiable, Insertable, Queryable,
 };
-use masking::{ExposeInterface, PeekInterface, Secret};
+use masking::{ExposeInterface, PeekInterface, Secret, StrongSecret};
 
 use crate::{
     crypto::{self, Encryption},
@@ -113,8 +113,8 @@ pub struct Fingerprint {
     pub card_fingerprint: Secret<String>,
 }
 
-#[derive(Debug, serde::Deserialize)]
-pub struct CardNumber(masking::StrongSecret<String>);
+#[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
+pub struct CardNumber(StrongSecret<String>);
 
 impl Validation for CardNumber {
     type Error = error::ApiError;
@@ -129,6 +129,14 @@ impl Validation for CardNumber {
 impl CardNumber {
     pub fn into_bytes(self) -> Vec<u8> {
         self.0.peek().clone().into_bytes()
+    }
+}
+
+impl std::ops::Deref for CardNumber {
+    type Target = StrongSecret<String>;
+
+    fn deref(&self) -> &StrongSecret<String> {
+        &self.0
     }
 }
 

--- a/src/validations.rs
+++ b/src/validations.rs
@@ -3,21 +3,30 @@ use crate::error::ApiError;
 ///
 /// Minimum limit of a card number will not deceed 8 by ISO standards
 ///
-const MIN_CARD_NUMBER_LENGTH: usize = 8;
+pub const MIN_CARD_NUMBER_LENGTH: usize = 8;
 
 ///
 /// Maximum limit of a card number will not exceed 19 by ISO standards
 ///
-const MAX_CARD_NUMBER_LENGTH: usize = 19;
+pub const MAX_CARD_NUMBER_LENGTH: usize = 19;
+
+pub fn sanitize_card_number(card_number: &str) -> Result<bool, ApiError> {
+    let card_number = card_number.split_whitespace().collect::<String>();
+
+    let is_card_number_valid = Ok(card_number.as_str())
+        .and_then(validate_card_number_chars)
+        .and_then(validate_card_number_length)
+        .map(|number| luhn(&number))?;
+
+    Ok(is_card_number_valid)
+}
 
 ///
 /// # Panics
 ///
 /// Never, as a single character will never be greater than 10, or `u8`
 ///
-pub fn validate_card_number(number: &str) -> Result<bool, ApiError> {
-    let number = number.split_whitespace().collect::<String>();
-
+pub fn validate_card_number_chars(number: &str) -> Result<Vec<u8>, ApiError> {
     let data = number.chars().try_fold(
         Vec::with_capacity(MAX_CARD_NUMBER_LENGTH),
         |mut data, character| {
@@ -35,11 +44,15 @@ pub fn validate_card_number(number: &str) -> Result<bool, ApiError> {
         },
     )?;
 
-    Ok(
-        (data.len() >= MIN_CARD_NUMBER_LENGTH && data.len() <= MAX_CARD_NUMBER_LENGTH)
-            .then(|| luhn(&data))
-            .unwrap_or(false),
-    )
+    Ok(data)
+}
+
+pub fn validate_card_number_length(number: Vec<u8>) -> Result<Vec<u8>, ApiError> {
+    if number.len() >= MIN_CARD_NUMBER_LENGTH && number.len() <= MAX_CARD_NUMBER_LENGTH {
+        Ok(number)
+    } else {
+        Err(ApiError::ValidationError("invalid card number length"))
+    }
 }
 
 #[allow(clippy::as_conversions)]

--- a/src/validations.rs
+++ b/src/validations.rs
@@ -1,25 +1,28 @@
 use crate::error::ApiError;
 
-const MIN_CARD_NUMBER_LENGTH: usize = 12;
+///
+/// Minimum limit of a card number will not deceed 8 by ISO standards
+///
+const MIN_CARD_NUMBER_LENGTH: usize = 8;
 
 ///
 /// Maximum limit of a card number will not exceed 19 by ISO standards
 ///
 const MAX_CARD_NUMBER_LENGTH: usize = 19;
 
-#[allow(clippy::expect_used)]
 ///
 /// # Panics
 ///
 /// Never, as a single character will never be greater than 10, or `u8`
 ///
-pub fn luhn_on_string(number: &str) -> Result<bool, ApiError> {
+pub fn validate_card_number(number: &str) -> Result<bool, ApiError> {
     let number = number.split_whitespace().collect::<String>();
 
-    let data = number
-        .chars()
-        .try_fold(Vec::with_capacity(20), |mut data, character| {
+    let data = number.chars().try_fold(
+        Vec::with_capacity(MAX_CARD_NUMBER_LENGTH),
+        |mut data, character| {
             data.push(
+                #[allow(clippy::expect_used)]
                 character
                     .to_digit(10)
                     .ok_or(ApiError::ValidationError(
@@ -29,7 +32,8 @@ pub fn luhn_on_string(number: &str) -> Result<bool, ApiError> {
                     .expect("error while converting a single character to u8"), // safety, a single character will never be greater `u8`
             );
             Ok::<Vec<u8>, ApiError>(data)
-        })?;
+        },
+    )?;
 
     Ok(
         (data.len() >= MIN_CARD_NUMBER_LENGTH && data.len() <= MAX_CARD_NUMBER_LENGTH)


### PR DESCRIPTION
This PR addresses the non-digit character cases in card number validation and raises an appropriate error if fails. 
This PR also includes min and max length check for card number.

## Test cases

1. Card number containing some invalid character

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/e6e167a2-27df-4ffa-962c-e992d0834a25)

2. `109` passes luhn but fails the card length constraint 

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/e3d3b225-b1c2-4b0b-a5ec-e020b1877a85)

3. Invalid card number not passing luhn

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/7d30fa63-cc5c-4e3c-b9e4-029802747a5c)

