### PR TITLE
refactor: record `tenant_id` header field in request trace

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -1,4 +1,4 @@
-use axum::routing;
+use axum::{extract::Request, routing};
 use error_stack::ResultExt;
 use tower_http::trace as tower_trace;
 
@@ -8,6 +8,7 @@ use crate::{
     config::{self, GlobalConfig, TenantConfig},
     error, routes, storage,
     tenant::GlobalAppState,
+    utils,
 };
 
 #[cfg(feature = "caching")]
@@ -116,6 +117,7 @@ where
 
     let router = router.with_state(global_app_state.clone()).layer(
         tower_trace::TraceLayer::new_for_http()
+            .make_span_with(|request: &Request<_>| utils::record_tenant_id_from_header(request))
             .on_request(tower_trace::DefaultOnRequest::new().level(tracing::Level::INFO))
             .on_response(
                 tower_trace::DefaultOnResponse::new()

--- a/src/error/container.rs
+++ b/src/error/container.rs
@@ -37,6 +37,7 @@ where
     for<'a> U: From<&'a T> + Sync + Send,
     Self: ErrorTransform<ContainerError<T>>,
 {
+    #[track_caller]
     fn from(value: ContainerError<T>) -> Self {
         let new_error = value.error.current_context().into();
         Self {

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -70,7 +70,7 @@ pub async fn key1(
         .entry(tenant_id.to_string())
         .and_modify(|key_state_data| key_state_data.key1 = Some(payload.key));
 
-    logger::info!("Received key1 for tenant - {tenant_id}");
+    logger::info!("Received key1");
     Json(CustodianRespPayload {
         message: "Received Key1".into(),
     })
@@ -87,7 +87,7 @@ pub async fn key2(
         .entry(tenant_id.to_string())
         .and_modify(|key_state_data| key_state_data.key2 = Some(payload.key));
 
-    logger::info!("Received key2 for tenant - {tenant_id}");
+    logger::info!("Received key2");
     Json(CustodianRespPayload {
         message: "Received Key2".into(),
     })
@@ -123,15 +123,13 @@ pub async fn decrypt(
 
             global_app_state.set_app_state(tenant_app_state).await;
 
-            logger::info!("Decryption of Custodian key is successful for tenant: {tenant_id}");
+            logger::info!("Decryption of Custodian key is successful");
             Ok(Json(CustodianRespPayload {
                 message: "Decryption of Custodian key is successful".into(),
             }))
         }
         _ => {
-            logger::error!(
-                "Both the custodian keys are not present to decrypt for tenant: {tenant_id}"
-            );
+            logger::error!("Both the custodian keys are not present to decrypt");
             Err(error::ApiError::DecryptingKeysFailed(
                 "Both the custodain keys are not present to decrypt",
             ))
@@ -159,7 +157,10 @@ async fn aes_decrypt_custodian_key(
         hex::decode(custodian_key)
             .change_error(error::ApiError::DecryptingKeysFailed("Hex dcoding failed"))?,
     )
-    .decrypt(tenant_config.tenant_secrets.master_key.clone())?;
+    .decrypt(tenant_config.tenant_secrets.master_key.clone())
+    .change_error(error::ApiError::DecryptingKeysFailed(
+        "AES decryption failed",
+    ))?;
 
     tenant_config.tenant_secrets.master_key = aes_decrypted_master_key;
     Ok(())

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,3 +1,5 @@
+use axum::{body::Body, extract::Request};
+
 /// Date-time utilities.
 pub mod date_time {
     use time::{OffsetDateTime, PrimitiveDateTime};
@@ -6,5 +8,23 @@ pub mod date_time {
     pub fn now() -> PrimitiveDateTime {
         let utc_date_time = OffsetDateTime::now_utc();
         PrimitiveDateTime::new(utc_date_time.date(), utc_date_time.time())
+    }
+}
+
+/// Record the tenant_id field in request's trace
+pub fn record_tenant_id_from_header(request: &Request<Body>) -> tracing::Span {
+    macro_rules! inner_trace {
+        ($v:expr) => {
+            tracing::debug_span!("request", method = %request.method(), uri = %request.uri(), version = ?request.version(), tenant_id = $v)
+        };
+    }
+
+    match request
+        .headers()
+        .get("x-tenant-id")
+        .and_then(|value| value.to_str().ok())
+    {
+        Some(value) => inner_trace!(value),
+        None => inner_trace!(tracing::field::Empty),
     }
 }


### PR DESCRIPTION
This PR records the `tenant_id` header field in each request's trace. This PR also maps the CryptoError::DecryptionError to ApiError::DecryptingKeysFailed