### PR TITLE
refactor: remove `tenant_id` column from all existing tables

### DIFF
--- a/migrations/2024-06-21-105740_remove_tenant_id_column_from_all_tables/down.sql
+++ b/migrations/2024-06-21-105740_remove_tenant_id_column_from_all_tables/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE merchant ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(255) NOT NULL;
+ALTER TABLE merchant DROP CONSTRAINT merchant_pkey, ADD CONSTRAINT merchant_pkey PRIMARY KEY (tenant_id, merchant_id);
+
+ALTER TABLE locker ADD COLUMN IF NOT EXISTS tenant_id VARCHAR(255) NOT NULL;
+ALTER TABLE locker DROP CONSTRAINT locker_pkey, ADD CONSTRAINT locker_pkey PRIMARY KEY (tenant_id, merchant_id, customer_id, locker_id);

--- a/migrations/2024-06-21-105740_remove_tenant_id_column_from_all_tables/up.sql
+++ b/migrations/2024-06-21-105740_remove_tenant_id_column_from_all_tables/up.sql
@@ -1,0 +1,8 @@
+-- Your SQL goes here
+ALTER TABLE merchant DROP CONSTRAINT merchant_pkey, ADD CONSTRAINT merchant_pkey PRIMARY KEY (merchant_id);
+ALTER TABLE merchant DROP COLUMN IF EXISTS tenant_id;
+
+ALTER TABLE locker DROP CONSTRAINT locker_pkey, ADD CONSTRAINT locker_pkey PRIMARY KEY (merchant_id, customer_id, locker_id);
+ALTER TABLE locker DROP COLUMN IF EXISTS tenant_id;
+
+

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -8,13 +8,11 @@ use crate::{
 
 use super::types::{self, DataDuplicationCheck};
 
-impl<'a> TryFrom<(super::types::StoreCardRequest, &'a str, &'a str)>
-    for storage::types::LockerNew<'a>
-{
+impl<'a> TryFrom<(super::types::StoreCardRequest, &'a str)> for storage::types::LockerNew<'a> {
     type Error = ContainerError<error::ApiError>;
 
     fn try_from(
-        (value, tenant_id, hash_id): (super::types::StoreCardRequest, &'a str, &'a str),
+        (value, hash_id): (super::types::StoreCardRequest, &'a str),
     ) -> Result<Self, Self::Error> {
         let data = match value.data {
             types::Data::Card { card } => Ok(types::StoredData::CardData(card)),
@@ -29,7 +27,6 @@ impl<'a> TryFrom<(super::types::StoreCardRequest, &'a str, &'a str)>
                 .requestor_card_reference
                 .unwrap_or_else(generate_uuid)
                 .into(),
-            tenant_id,
             merchant_id: value.merchant_id,
             customer_id: value.merchant_customer_id,
             enc_data: data.into(),

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -87,7 +87,7 @@ pub trait Cacheable<Table> {
 
 #[cfg(feature = "caching")]
 impl Cacheable<types::Merchant> for Storage {
-    type Key = (String, String);
+    type Key = String;
     type Value = types::Merchant;
 }
 
@@ -111,20 +111,18 @@ pub(crate) trait MerchantInterface {
     type Algorithm: Encryption<Vec<u8>, Vec<u8>> + Sync;
     type Error;
 
-    /// find merchant from merchant table with `merchant_id` and `tenant_id` with key as master key
+    /// find merchant from merchant table with `merchant_id` with key as master key
     async fn find_by_merchant_id(
         &self,
         merchant_id: &str,
-        tenant_id: &str,
         key: &Self::Algorithm,
     ) -> Result<types::Merchant, ContainerError<Self::Error>>;
 
-    /// find merchant from merchant table with `merchant_id` and `tenant_id` with key as master key
+    /// find merchant from merchant table with `merchant_id` with key as master key
     /// and if not found create a new merchant
     async fn find_or_create_by_merchant_id(
         &self,
         merchant_id: &str,
-        tenant_id: &str,
         key: &Self::Algorithm,
     ) -> Result<types::Merchant, ContainerError<Self::Error>>;
 
@@ -148,7 +146,6 @@ pub(crate) trait LockerInterface {
     async fn find_by_locker_id_merchant_id_customer_id(
         &self,
         locker_id: Secret<String>,
-        tenant_id: &str,
         merchant_id: &str,
         customer_id: &str,
         key: &Self::Algorithm,
@@ -165,7 +162,6 @@ pub(crate) trait LockerInterface {
     async fn delete_from_locker(
         &self,
         locker_id: Secret<String>,
-        tenant_id: &str,
         merchant_id: &str,
         customer_id: &str,
     ) -> Result<usize, ContainerError<Self::Error>>;
@@ -173,7 +169,6 @@ pub(crate) trait LockerInterface {
     async fn find_by_hash_id_merchant_id_customer_id(
         &self,
         hash_id: &str,
-        tenant_id: &str,
         merchant_id: &str,
         customer_id: &str,
         key: &Self::Algorithm,

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -20,12 +20,10 @@ diesel::table! {
 }
 
 diesel::table! {
-    locker (tenant_id, merchant_id, customer_id, locker_id) {
+    locker (merchant_id, customer_id, locker_id) {
         id -> Int4,
         #[max_length = 255]
         locker_id -> Varchar,
-        #[max_length = 255]
-        tenant_id -> Varchar,
         #[max_length = 255]
         merchant_id -> Varchar,
         #[max_length = 255]
@@ -39,10 +37,8 @@ diesel::table! {
 }
 
 diesel::table! {
-    merchant (tenant_id, merchant_id) {
+    merchant (merchant_id) {
         id -> Int4,
-        #[max_length = 255]
-        tenant_id -> Varchar,
         #[max_length = 255]
         merchant_id -> Varchar,
         enc_key -> Bytea,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -18,7 +18,6 @@ use super::schema;
 #[diesel(table_name = schema::merchant)]
 pub(super) struct MerchantInner {
     id: i32,
-    tenant_id: String,
     merchant_id: String,
     enc_key: Encrypted,
     created_at: time::PrimitiveDateTime,
@@ -26,7 +25,6 @@ pub(super) struct MerchantInner {
 
 #[derive(Debug, Clone)]
 pub struct Merchant {
-    pub tenant_id: String,
     pub merchant_id: String,
     pub enc_key: Secret<Vec<u8>>,
     pub created_at: time::PrimitiveDateTime,
@@ -35,14 +33,12 @@ pub struct Merchant {
 #[derive(Debug, Insertable)]
 #[diesel(table_name = schema::merchant)]
 pub(super) struct MerchantNewInner<'a> {
-    tenant_id: &'a str,
     merchant_id: &'a str,
     enc_key: Encrypted,
 }
 
 #[derive(Debug)]
 pub struct MerchantNew<'a> {
-    pub tenant_id: &'a str,
     pub merchant_id: &'a str,
     pub enc_key: Secret<Vec<u8>>,
 }
@@ -52,7 +48,6 @@ pub struct MerchantNew<'a> {
 pub(super) struct LockerInner {
     id: i32,
     locker_id: Secret<String>,
-    tenant_id: String,
     merchant_id: String,
     customer_id: String,
     enc_data: Encrypted,
@@ -64,7 +59,6 @@ pub(super) struct LockerInner {
 #[derive(Debug)]
 pub struct Locker {
     pub locker_id: Secret<String>,
-    pub tenant_id: String,
     pub merchant_id: String,
     pub customer_id: String,
     pub enc_data: Secret<Vec<u8>>,
@@ -76,7 +70,6 @@ pub struct Locker {
 #[derive(Debug, Clone)]
 pub struct LockerNew<'a> {
     pub locker_id: Secret<String>,
-    pub tenant_id: &'a str,
     pub merchant_id: String,
     pub customer_id: String,
     pub enc_data: Secret<Vec<u8>>,
@@ -88,7 +81,6 @@ pub struct LockerNew<'a> {
 #[diesel(table_name = schema::locker)]
 pub(super) struct LockerNewInner<'a> {
     locker_id: Secret<String>,
-    tenant_id: &'a str,
     merchant_id: String,
     customer_id: String,
     enc_data: Encrypted,
@@ -253,7 +245,6 @@ impl StorageDecryption for MerchantInner {
             merchant_id: self.merchant_id,
             enc_key: algo.decrypt(self.enc_key.into_inner().expose())?.into(),
             created_at: self.created_at,
-            tenant_id: self.tenant_id,
         })
     }
 }
@@ -270,7 +261,6 @@ impl<'a> StorageEncryption for MerchantNew<'a> {
         Ok(Self::Output {
             merchant_id: self.merchant_id,
             enc_key: algo.encrypt(self.enc_key.expose())?.into(),
-            tenant_id: self.tenant_id,
         })
     }
 }
@@ -286,7 +276,6 @@ impl StorageDecryption for LockerInner {
     ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output> {
         Ok(Self::Output {
             locker_id: self.locker_id,
-            tenant_id: self.tenant_id,
             merchant_id: self.merchant_id,
             customer_id: self.customer_id,
             enc_data: algo.decrypt(self.enc_data.into_inner().expose())?.into(),
@@ -308,7 +297,6 @@ impl<'a> StorageEncryption for LockerNew<'a> {
     ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output> {
         Ok(Self::Output {
             locker_id: self.locker_id,
-            tenant_id: self.tenant_id,
             merchant_id: self.merchant_id,
             customer_id: self.customer_id,
             enc_data: algo.encrypt(self.enc_data.expose())?.into(),


### PR DESCRIPTION
This PR removes the `tenant_id` column from all the existing tables

## Test case

Made a save card payment from hyperswitch - 

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/763e6023-ebf9-409d-8160-ba8f64024ebd)

DB schema after `tenant_id` removal - 

1. Merchant table 

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/dd261991-8861-4385-b0f9-ae1d1eb8c5fa)

2. Locker table 

![image](https://github.com/juspay/hyperswitch-card-vault/assets/70657455/2edbd8fe-ec2c-4c05-9618-52a953f51be6)
