### PR TITLE
refactor: add db migrations for v2

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -100,6 +100,7 @@ harness = false
 [lints.rust]
 unsafe_code = "forbid"
 rust_2018_idioms = { level = "warn", priority = -1 }
+deprecated = "allow"
 
 [lints.clippy]
 as_conversions = "warn"

--- a/migrations/2024-07-02-071458_v2-migrations/down.sql
+++ b/migrations/2024-07-02-071458_v2-migrations/down.sql
@@ -1,0 +1,7 @@
+-- This file should undo anything in `up.sql`
+
+ALTER TABLE fingerprint RENAME COLUMN fingerprint_id TO card_fingerprint;
+ALTER TABLE fingerprint RENAME COLUMN fingerprint_hash TO card_hash;
+
+DROP TABLE IF EXISTS vault;
+DROP TABLE IF EXISTS entity;

--- a/migrations/2024-07-02-071458_v2-migrations/up.sql
+++ b/migrations/2024-07-02-071458_v2-migrations/up.sql
@@ -1,0 +1,21 @@
+-- Your SQL goes here
+
+ALTER TABLE fingerprint RENAME COLUMN card_fingerprint TO fingerprint_id;
+ALTER TABLE fingerprint RENAME COLUMN card_hash TO fingerprint_hash;
+
+CREATE TABLE IF NOT EXISTS vault (
+    id SERIAL,
+    entity_id VARCHAR(255) NOT NULL, 
+    vault_id VARCHAR(255) NOT NULL,
+    encrypted_data BYTEA NOT NULL,
+    created_at TIMESTAMP NOT NULL DEFAULT now()::TIMESTAMP,
+    expires_at TIMESTAMP DEFAULT NULL,
+    
+    PRIMARY KEY (entity_id, vault_id)
+);
+
+CREATE TABLE IF NOT EXISTS entity {
+    id SERIAL,
+    entity_id VARCHAR(255) NOT NULL,
+    enc_key_id VARCHAR(255) NOT NULL
+}

--- a/migrations/2024-07-02-071458_v2-migrations/up.sql
+++ b/migrations/2024-07-02-071458_v2-migrations/up.sql
@@ -14,8 +14,10 @@ CREATE TABLE IF NOT EXISTS vault (
     PRIMARY KEY (entity_id, vault_id)
 );
 
-CREATE TABLE IF NOT EXISTS entity {
+CREATE TABLE IF NOT EXISTS entity (
     id SERIAL,
     entity_id VARCHAR(255) NOT NULL,
-    enc_key_id VARCHAR(255) NOT NULL
-}
+    enc_key_id VARCHAR(255) NOT NULL,
+
+    PRIMARY KEY (entity_id)
+);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(deprecated)]
-
 pub mod app;
 pub mod config;
 pub mod crypto;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,5 @@
+#![allow(deprecated)]
+
 pub mod app;
 pub mod config;
 pub mod crypto;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -107,6 +107,10 @@ impl Cacheable<types::Fingerprint> for Storage {
 /// MerchantInterface:
 ///
 /// Interface providing functional to interface with the merchant table in database
+#[deprecated(
+    since = "1.0.0",
+    note = "separate encryption service is being used to store DEK"
+)]
 pub(crate) trait MerchantInterface {
     type Algorithm: Encryption<Vec<u8>, Vec<u8>> + Sync;
     type Error;
@@ -177,6 +181,10 @@ pub(crate) trait LockerInterface {
 
 /// Trait defining behaviour of the application with the hash table, providing APIs to interact
 /// with it
+#[deprecated(
+    since = "1.0.0",
+    note = "duplication of data should now be handled on the client side"
+)]
 pub(crate) trait HashInterface {
     type Error;
 
@@ -202,9 +210,9 @@ pub(crate) trait TestInterface {
 pub(crate) trait FingerprintInterface {
     type Error;
 
-    async fn find_by_card_hash(
+    async fn find_by_fingerprint_hash(
         &self,
-        card_hash: Secret<&[u8]>,
+        fingerprint_hash: Secret<&[u8]>,
     ) -> Result<Option<types::Fingerprint>, ContainerError<Self::Error>>;
 
     async fn insert_fingerprint(

--- a/src/storage/caching/fingerprint.rs
+++ b/src/storage/caching/fingerprint.rs
@@ -16,16 +16,19 @@ where
 {
     type Error = T::Error;
 
-    async fn find_by_card_hash(
+    async fn find_by_fingerprint_hash(
         &self,
-        card_hash: Secret<&[u8]>,
+        fingerprint_hash: Secret<&[u8]>,
     ) -> Result<Option<types::Fingerprint>, ContainerError<Self::Error>> {
-        let key = card_hash.peek().to_vec();
+        let key = fingerprint_hash.peek().to_vec();
         let cached_data = self.lookup::<types::Fingerprint>(key.clone()).await;
         match cached_data {
             Some(data) => Ok(Some(data)),
             None => {
-                let result = self.inner.find_by_card_hash(card_hash).await?;
+                let result = self
+                    .inner
+                    .find_by_fingerprint_hash(fingerprint_hash)
+                    .await?;
                 if let Some(ref fingerprint) = result {
                     self.cache_data::<types::Fingerprint>(key, fingerprint.clone())
                         .await;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,6 +1,16 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    entity (entity_id) {
+        id -> Int4,
+        #[max_length = 255]
+        entity_id -> Varchar,
+        #[max_length = 255]
+        enc_key_id -> Varchar,
+    }
+}
+
+diesel::table! {
     fingerprint (fingerprint_hash) {
         id -> Int4,
         fingerprint_hash -> Bytea,
@@ -59,4 +69,11 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(fingerprint, hash_table, locker, merchant, vault,);
+diesel::allow_tables_to_appear_in_same_query!(
+    entity,
+    fingerprint,
+    hash_table,
+    locker,
+    merchant,
+    vault,
+);

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,11 +1,11 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
-    fingerprint (card_hash) {
+    fingerprint (fingerprint_hash) {
         id -> Int4,
-        card_hash -> Bytea,
+        fingerprint_hash -> Bytea,
         #[max_length = 64]
-        card_fingerprint -> Varchar,
+        fingerprint_id -> Varchar,
     }
 }
 
@@ -46,4 +46,17 @@ diesel::table! {
     }
 }
 
-diesel::allow_tables_to_appear_in_same_query!(fingerprint, hash_table, locker, merchant,);
+diesel::table! {
+    vault (entity_id, vault_id) {
+        id -> Int4,
+        #[max_length = 255]
+        entity_id -> Varchar,
+        #[max_length = 255]
+        vault_id -> Varchar,
+        encrypted_data -> Bytea,
+        created_at -> Timestamp,
+        expires_at -> Nullable<Timestamp>,
+    }
+}
+
+diesel::allow_tables_to_appear_in_same_query!(fingerprint, hash_table, locker, merchant, vault,);

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -135,8 +135,8 @@ impl std::ops::Deref for CardNumber {
 #[derive(Debug, Insertable)]
 #[diesel(table_name = schema::fingerprint)]
 pub(super) struct FingerprintTableNew {
-    pub card_hash: Secret<Vec<u8>>,
-    pub card_fingerprint: Secret<String>,
+    pub fingerprint_hash: Secret<Vec<u8>>,
+    pub fingerprint_id: Secret<String>,
 }
 
 #[derive(Debug, Insertable)]


### PR DESCRIPTION
This PR adds db migrations required for v2

* Rename fingerprint column names
* Add `vault` table for storing data 
* Add `entity` table for storing `key_id` of encryption service for each entity