### PR TITLE
feat: integrate a secret manager

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -452,7 +452,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.0",
  "hyper-util",
  "itoa",
  "matchit",
@@ -506,7 +506,7 @@ dependencies = [
  "http 1.0.0",
  "http-body 1.0.0",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.0",
  "hyper-util",
  "pin-project-lite",
  "rustls",
@@ -531,7 +531,7 @@ dependencies = [
  "cookie",
  "http 1.0.0",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.0",
  "hyper-util",
  "mime",
  "pretty_assertions",
@@ -630,9 +630,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 
 [[package]]
 name = "bytes-utils"
@@ -1522,9 +1522,9 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.1.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb5aa53871fc917b1a9ed87b683a5d86db645e23acb32c2e0785a353e522fb75"
+checksum = "c4fe55fb7a772d59a5ff1dfbff4fe0258d19b89fec4b233e75d35d5d2316badc"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -1536,6 +1536,7 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
+ "smallvec",
  "tokio",
  "want",
 ]
@@ -1557,6 +1558,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-tls"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
+dependencies = [
+ "bytes",
+ "hyper 0.14.28",
+ "native-tls",
+ "tokio",
+ "tokio-native-tls",
+]
+
+[[package]]
 name = "hyper-util"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1567,7 +1581,7 @@ dependencies = [
  "futures-util",
  "http 1.0.0",
  "http-body 1.0.0",
- "hyper 1.1.0",
+ "hyper 1.4.0",
  "pin-project-lite",
  "socket2",
  "tokio",
@@ -1829,6 +1843,23 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ffa00dec017b5b1a8b7cf5e2c008bfda1aa7e0697ac1508b491fdf2622fb4d8"
 dependencies = [
  "rand",
+]
+
+[[package]]
+name = "native-tls"
+version = "0.2.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a8614eb2c83d59d1c8cc974dd3f920198647674a0a035e1af1fa58707e317466"
+dependencies = [
+ "libc",
+ "log",
+ "openssl",
+ "openssl-probe",
+ "openssl-sys",
+ "schannel",
+ "security-framework",
+ "security-framework-sys",
+ "tempfile",
 ]
 
 [[package]]
@@ -2361,9 +2392,9 @@ checksum = "c08c74e62047bb2de4ff487b251e4a92e24f48745648451635cec7d591162d9f"
 
 [[package]]
 name = "reqwest"
-version = "0.11.23"
+version = "0.11.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37b1ae8d9ac08420c66222fb9096fc5de435c3c48542bc5336c51892cffafb41"
+checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
 dependencies = [
  "base64 0.21.7",
  "bytes",
@@ -2375,10 +2406,12 @@ dependencies = [
  "http-body 0.4.6",
  "hyper 0.14.28",
  "hyper-rustls",
+ "hyper-tls",
  "ipnet",
  "js-sys",
  "log",
  "mime",
+ "native-tls",
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
@@ -2387,8 +2420,10 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
+ "sync_wrapper",
  "system-configuration",
  "tokio",
+ "tokio-native-tls",
  "tokio-rustls",
  "tower-service",
  "url",
@@ -2939,6 +2974,7 @@ dependencies = [
  "axum-server",
  "axum-test",
  "base64 0.21.7",
+ "bytes",
  "cargo_metadata 0.18.1",
  "config",
  "criterion",
@@ -2951,13 +2987,14 @@ dependencies = [
  "gethostname",
  "hex",
  "http-body-util",
- "hyper 1.1.0",
+ "hyper 1.4.0",
  "josekit",
  "masking",
  "moka",
  "nanoid",
  "once_cell",
  "rand",
+ "reqwest",
  "ring 0.16.20",
  "rustc-hash",
  "serde",
@@ -3102,6 +3139,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.48",
+]
+
+[[package]]
+name = "tokio-native-tls"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
+dependencies = [
+ "native-tls",
+ "tokio",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,12 +16,14 @@ limit = []
 middleware = []
 key_custodian = []
 caching = ["dep:moka"]
+keymanager_mtls = []
 
 [dependencies]
 async-trait = "0.1.79"
 aws-config = { version = "1.0.1", optional = true }
 aws-sdk-kms = { version = "1.3.0", optional = true }
 base64 = "0.21.2"
+bytes = "1.6.0"
 futures = "0.3.28"
 gethostname = "0.4.3"
 rustc-hash = "1.1"
@@ -60,6 +62,7 @@ hex = "0.4.3"
 time = { version = "0.3.35", features = ["serde"] }
 uuid = { version = "1.5.0", features = ["v4", "fast-rng"] }
 moka = { version = "0.12.1", features = ["future"], optional = true }
+reqwest = { version = "0.11.27", features = ["json", "__rustls"] }
 
 argh = "0.1.12"
 

--- a/config.example.toml
+++ b/config.example.toml
@@ -59,6 +59,17 @@ hyperswitch = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d
 # token = "hvs.abc" # The secret token to access and communicate with the vault
 
 # TLS server within axum
-# [tls]
-# certificate = "cert.pem" # path to the certificate file (`pem` format)
-# private_key = "key.pem" # path to the private key file (`pem` format)
+[tls]
+certificate = "cert.pem" # path to the certificate file (`pem` format)
+private_key = "key.pem" # path to the private key file (`pem` format)
+
+# Api client
+[api_client]
+client_idle_timeout = 90 # timeout for idle sockets being kept-alive
+pool_max_idle_per_host = 10 # maximum idle connection per host allowed in the pool.
+identity = "" # identity to be used for client certificate authentication in mtls.
+
+# Configuration for the Key Manager Service
+[key_manager]
+url = "http://localhost:5000" # URL of the encryption service
+cert = "" # Represents a server X509 certificate for mtls

--- a/config/development.toml
+++ b/config/development.toml
@@ -54,7 +54,7 @@ Sau7H1Bhzy5G7rwt05LNpU6nFcAGVaZtzl4/+FYfYIulubYjuSEh72yuBHHyvi1/
 """
 
 [tenant_secrets]
-"hyperswitch" = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
+"public" = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Z/K0JWds8iHhWCa+rj0
 rhOQX1nVs/ArQ1D0vh3UlSPR2vZUTrkdP7i3amv4d2XDC+3+5/YWExTkpxqnfl1T
@@ -65,3 +65,6 @@ APK2BjMQ2AMkUxx0ubbtw/9CeJ+bFWrqGnEhlvfDMlyAV77sAiIdQ4mXs3TLcLb/
 AQIDAQAB
 -----END PUBLIC KEY-----
 """ }
+
+[key_manager]
+url = "http://localhost:5000"

--- a/config/docker-configuration.toml
+++ b/config/docker-configuration.toml
@@ -60,3 +60,12 @@ region = "abc"
 [tls]
 certificate = "cert.pem"
 private_key = "key.pem"
+
+[api_client]
+client_idle_timeout = 90
+pool_max_idle_per_host = 10
+identity = ""
+
+[key_manager]
+url = "http://localhost:5000"
+cert = ""

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -74,17 +74,15 @@ impl ApiClient {
 
         #[cfg(feature = "keymanager_mtls")]
         {
-            let client_identity = reqwest::Identity::from_pem(
-                global_config.api_client.identity.clone().peek().as_ref(),
-            )
-            .change_error(error::ApiClientError::IdentityParseFailed)?;
+            let client_identity =
+                reqwest::Identity::from_pem(global_config.api_client.identity.peek().as_ref())
+                    .change_error(error::ApiClientError::IdentityParseFailed)?;
 
-            let key_manager_cert = reqwest::Certificate::from_pem(
-                global_config.key_manager.cert.clone().peek().as_ref(),
-            )
-            .change_error(error::ApiClientError::CertificateParseFailed {
-                service: "key_manager",
-            })?;
+            let key_manager_cert =
+                reqwest::Certificate::from_pem(global_config.key_manager.cert.peek().as_ref())
+                    .change_error(error::ApiClientError::CertificateParseFailed {
+                        service: "key_manager",
+                    })?;
 
             client = client
                 .use_rustls_tls()

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,0 +1,153 @@
+use std::str::FromStr;
+
+use crate::{
+    config::GlobalConfig,
+    error::{self, ResultContainerExt},
+};
+use error_stack::{Report, ResultExt};
+use masking::Maskable;
+#[cfg(feature = "keymanager_mtls")]
+use masking::PeekInterface;
+use reqwest::header::{HeaderMap, HeaderName, HeaderValue};
+use reqwest::StatusCode;
+
+pub type Headers = std::collections::HashSet<(String, Maskable<String>)>;
+
+pub(super) trait HeaderExt {
+    fn construct_header_map(self) -> Result<HeaderMap, Report<error::ApiClientError>>;
+}
+
+impl HeaderExt for Headers {
+    fn construct_header_map(self) -> Result<HeaderMap, Report<error::ApiClientError>> {
+        self.into_iter().try_fold(
+            HeaderMap::new(),
+            |mut header_map, (header_name, header_value)| {
+                let header_name = HeaderName::from_str(&header_name)
+                    .change_context(error::ApiClientError::HeaderMapConstructionFailed)?;
+                let header_value = header_value.into_inner();
+                let header_value = HeaderValue::from_str(&header_value)
+                    .change_context(error::ApiClientError::HeaderMapConstructionFailed)?;
+                header_map.append(header_name, header_value);
+                Ok(header_map)
+            },
+        )
+    }
+}
+
+#[derive(Clone, serde::Deserialize, Debug)]
+#[serde(default)]
+pub struct ApiClientConfig {
+    pub client_idle_timeout: u64,
+    pub pool_max_idle_per_host: usize,
+    // KMS encrypted
+    #[cfg(feature = "keymanager_mtls")]
+    pub identity: masking::Secret<String>,
+}
+
+#[derive(Clone)]
+pub struct ApiClient {
+    pub inner: reqwest::Client,
+}
+
+impl std::ops::Deref for ApiClient {
+    type Target = reqwest::Client;
+
+    fn deref(&self) -> &Self::Target {
+        &self.inner
+    }
+}
+
+impl ApiClient {
+    #[allow(unused_mut)]
+    pub fn new(global_config: &GlobalConfig) -> Result<Self, Report<error::ApiClientError>> {
+        let mut client = reqwest::Client::builder()
+            .redirect(reqwest::redirect::Policy::none())
+            .pool_idle_timeout(std::time::Duration::from_secs(
+                global_config.api_client.client_idle_timeout,
+            ))
+            .pool_max_idle_per_host(global_config.api_client.pool_max_idle_per_host);
+
+        #[cfg(feature = "keymanager_mtls")]
+        {
+            let client_identity = reqwest::Identity::from_pem(
+                global_config.api_client.identity.clone().peek().as_ref(),
+            )
+            .map_err(error::ApiClientError::IdentityParseFailed)?;
+
+            let key_manager_cert = reqwest::Certificate::from_pem(
+                global_config.key_manager.cert.clone().peek().as_ref(),
+            )
+            .map_err(|err| error::ApiClientError::CertificateParseFailed {
+                client: "key_manager",
+                error: err,
+            })?;
+
+            client = client
+                .use_rustls_tls()
+                .identity(client_identity)
+                .add_root_certificate(key_manager_cert)
+                .https_only(true);
+        }
+
+        let client = client
+            .build()
+            .change_context(error::ApiClientError::ClientConstructionFailed)?;
+
+        Ok(Self { inner: client })
+    }
+
+    pub async fn send_request<T, R>(
+        &self,
+        url: String,
+        headers: Headers,
+        request_body: T,
+    ) -> Result<R, error::ContainerError<error::ApiClientError>>
+    where
+        T: serde::Serialize + Send + Sync + 'static,
+        R: serde::de::DeserializeOwned,
+    {
+        let url =
+            reqwest::Url::parse(&url).change_error(error::ApiClientError::UrlEncodingFailed)?;
+
+        let headers = headers.construct_header_map()?;
+
+        let response = self
+            .post(url)
+            .json(&request_body)
+            .headers(headers)
+            .send()
+            .await
+            .map_err(|err| error::ApiClientError::RequestNotSent {
+                service: "secrets manager".into(),
+                message: err.to_string(),
+            })?;
+
+        match response.status() {
+            StatusCode::OK => response
+                .json::<R>()
+                .await
+                .change_error(error::ApiClientError::ResponseDecodingFailed),
+            StatusCode::INTERNAL_SERVER_ERROR => Err(error::ApiClientError::InternalServerError(
+                response
+                    .bytes()
+                    .await
+                    .change_error(error::ApiClientError::ResponseDecodingFailed)?,
+            )
+            .into()),
+            StatusCode::BAD_REQUEST => Err(error::ApiClientError::BadRequest(
+                response
+                    .bytes()
+                    .await
+                    .change_error(error::ApiClientError::ResponseDecodingFailed)?,
+            )
+            .into()),
+            _ => Err(error::ApiClientError::Unexpected(
+                response
+                    .bytes()
+                    .await
+                    .change_error(error::ApiClientError::ResponseDecodingFailed)?,
+            )
+            .into()),
+        }
+    }
+}

--- a/src/app.rs
+++ b/src/app.rs
@@ -53,7 +53,7 @@ impl TenantAppState {
     /// - If the database password cannot be parsed as a string after kms decrypt
     ///
     pub async fn new(
-        global_config: GlobalConfig,
+        global_config: &GlobalConfig,
         tenant_config: TenantConfig,
         api_client: ApiClient,
     ) -> error_stack::Result<Self, error::ConfigurationError> {

--- a/src/app.rs
+++ b/src/app.rs
@@ -6,6 +6,7 @@ use tower_http::trace as tower_trace;
 use std::sync::Arc;
 
 use crate::{
+    api_client::ApiClient,
     config::{self, GlobalConfig, TenantConfig},
     error, logger, routes, storage,
     tenant::GlobalAppState,
@@ -37,6 +38,7 @@ type Storage = storage::Storage;
 pub struct TenantAppState {
     pub db: Storage,
     pub config: config::TenantConfig,
+    pub api_client: ApiClient,
 }
 
 #[allow(clippy::expect_used)]
@@ -53,6 +55,7 @@ impl TenantAppState {
     pub async fn new(
         global_config: GlobalConfig,
         tenant_config: TenantConfig,
+        api_client: ApiClient,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
         let db = storage::Storage::new(&global_config.database, &tenant_config.tenant_id)
             .await
@@ -66,6 +69,7 @@ impl TenantAppState {
 
         Ok(Self {
             db,
+            api_client,
             config: tenant_config,
         })
     }

--- a/src/crypto.rs
+++ b/src/crypto.rs
@@ -1,8 +1,8 @@
 pub mod encryption_manager;
 pub mod hash_manager;
+pub mod keymanager;
 pub mod secrets_manager;
 
-#[cfg(feature = "kms-aws")]
 pub mod consts {
     /// General purpose base64 engine
     pub(crate) const BASE64_ENGINE: base64::engine::GeneralPurpose =

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -1,0 +1,120 @@
+pub mod types;
+
+use error_stack::ResultExt;
+
+use masking::ExposeInterface;
+use serde::Deserialize;
+
+use crate::{
+    app::TenantAppState,
+    crypto::keymanager::types::{
+        DataKeyCreateRequest, DataKeyCreateResponse, DataKeyTransferRequest, DecryptDataRequest,
+        DecryptDataResponse, EncryptDataRequest, EncryptDateResponse, EncryptedData,
+    },
+    error::{self, ContainerError, NotFoundError, ResultContainerExt},
+    storage::{types::Entity, EntityInterface},
+};
+
+#[derive(Debug, Deserialize, Clone)]
+pub struct KeyManagerConfig {
+    pub url: String,
+    // KMS encrypted
+    #[cfg(feature = "keymanager_mtls")]
+    pub cert: masking::Secret<String>,
+}
+
+pub async fn find_or_create_key_in_key_manager(
+    state: &TenantAppState,
+    entity_id: &str,
+    request_body: DataKeyCreateRequest,
+) -> Result<Entity, ContainerError<error::KeyManagerError>> {
+    let entity = state.db.find_by_entity_id(entity_id).await;
+
+    match entity {
+        Ok(entity) => Ok(entity),
+        Err(inner_err) => match inner_err.is_not_found() {
+            true => {
+                let url = format!("{}/key/create", state.config.key_manager.url);
+                let headers = [("Content-type".into(), "application/json".into())]
+                    .into_iter()
+                    .collect::<std::collections::HashSet<_>>();
+
+                let response = state
+                    .api_client
+                    .send_request::<_, DataKeyCreateResponse>(url, headers, request_body)
+                    .await
+                    .change_context(error::KeyManagerError::RequestSendFailed)?;
+
+                Ok(state
+                    .db
+                    .insert_entity(entity_id, &response.identifier.get_identifier())
+                    .await
+                    .change_context(error::KeyManagerError::KeyAddFailed)?)
+            }
+            false => Err(error::KeyManagerError::KeyAddFailed.into()),
+        },
+    }
+}
+
+pub async fn transfer_key_to_key_manager(
+    state: &TenantAppState,
+    entity_id: &str,
+    request_body: DataKeyTransferRequest,
+) -> Result<Entity, ContainerError<error::KeyManagerError>> {
+    let url = format!("{}/key/transfer", state.config.key_manager.url);
+    let headers = [("Content-type".into(), "application/json".into())]
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+
+    let response = state
+        .api_client
+        .send_request::<_, DataKeyCreateResponse>(url, headers, request_body)
+        .await
+        .change_error(error::KeyManagerError::RequestSendFailed)?;
+
+    state
+        .db
+        .insert_entity(entity_id, &response.identifier.get_identifier())
+        .await
+        .change_error(error::KeyManagerError::KeyAddFailed)
+}
+
+pub async fn encrypt_data_using_key_manager(
+    state: &TenantAppState,
+    request_body: EncryptDataRequest,
+) -> Result<EncryptedData, ContainerError<error::KeyManagerError>> {
+    let url = format!("{}/data/encrypt", state.config.key_manager.url);
+    let headers = [("Content-type".into(), "application/json".into())]
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+
+    let response = state
+        .api_client
+        .send_request::<_, EncryptDateResponse>(url, headers, request_body)
+        .await
+        .change_context(error::KeyManagerError::RequestSendFailed)?;
+
+    Ok(response.data)
+}
+
+pub async fn decrypt_data_using_key_manager<T>(
+    state: &TenantAppState,
+    request_body: DecryptDataRequest,
+) -> Result<T, ContainerError<error::KeyManagerError>>
+where
+    T: serde::de::DeserializeOwned,
+{
+    let url = format!("{}/data/decrypt", state.config.key_manager.url);
+    let headers = [("Content-type".into(), "application/json".into())]
+        .into_iter()
+        .collect::<std::collections::HashSet<_>>();
+
+    let response = state
+        .api_client
+        .send_request::<_, DecryptDataResponse>(url, headers, request_body)
+        .await
+        .change_context(error::KeyManagerError::RequestSendFailed)?;
+
+    serde_json::from_slice::<T>(&response.data.inner().expose())
+        .change_error(error::KeyManagerError::ResponseDecodingFailed)
+}

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -54,6 +54,8 @@ pub async fn find_or_create_key_in_key_manager(
     }
 }
 
+/// Method required to transfer the old dek of merchant to key manager.
+/// Can be removed after migration of all keys.
 pub async fn transfer_key_to_key_manager(
     state: &TenantAppState,
     entity_id: &str,

--- a/src/crypto/keymanager/types.rs
+++ b/src/crypto/keymanager/types.rs
@@ -59,7 +59,7 @@ pub struct DataEncryptionRequest {
 impl DataEncryptionRequest {
     pub fn create_request<T>(
         key_identifier: String,
-        data: &T,
+        data: &Secret<T>,
     ) -> Result<Self, error::ContainerError<error::ApiError>>
     where
         T: Serialize,
@@ -163,12 +163,12 @@ impl DecryptedData {
     pub fn inner(self) -> Secret<Vec<u8>> {
         self.0
     }
-    pub fn from_value<T>(data: &T) -> Result<Self, error::ContainerError<error::ApiError>>
+    pub fn from_value<T>(data: &Secret<T>) -> Result<Self, error::ContainerError<error::ApiError>>
     where
         T: Serialize,
     {
         Ok(Self(
-            serde_json::to_vec(data)
+            serde_json::to_vec(data.peek())
                 .change_error(error::ApiError::EncodingError)?
                 .into(),
         ))

--- a/src/crypto/keymanager/types.rs
+++ b/src/crypto/keymanager/types.rs
@@ -1,14 +1,15 @@
 use std::fmt;
 
 use crate::{
-    crypto,
+    crypto::{self, consts::BASE64_ENGINE},
+    error::{self, ResultContainerExt},
     storage::{consts, utils},
 };
 use base64::Engine;
-use masking::{PeekInterface, Secret};
+use masking::{ExposeInterface, PeekInterface, Secret};
 use serde::{
     de::{self, Unexpected, Visitor},
-    ser, Deserialize, Deserializer, Serialize,
+    Deserialize, Deserializer, Serialize, Serializer,
 };
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
@@ -55,8 +56,24 @@ pub struct DataEncryptionRequest {
     pub data: DecryptedData,
 }
 
+impl DataEncryptionRequest {
+    pub fn create_request<T>(
+        key_identifier: String,
+        data: &T,
+    ) -> Result<Self, error::ContainerError<error::ApiError>>
+    where
+        T: Serialize,
+    {
+        Ok(Self {
+            identifier: Identifier::Entity(key_identifier),
+            data: DecryptedData::from_value(data)?,
+        })
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize)]
 pub struct DateEncryptionResponse {
+    #[serde(serialize_with = "serialize_encryption_data")]
     pub data: EncryptedData,
 }
 
@@ -64,7 +81,17 @@ pub struct DateEncryptionResponse {
 pub struct DataDecryptionRequest {
     #[serde(flatten)]
     pub identifier: Identifier,
+    #[serde(serialize_with = "serialize_encryption_data")]
     pub data: EncryptedData,
+}
+
+impl DataDecryptionRequest {
+    pub fn create_request(key_identifier: String, data: Secret<Vec<u8>>) -> Self {
+        Self {
+            identifier: Identifier::Entity(key_identifier),
+            data: EncryptedData::from_secret(data),
+        }
+    }
 }
 
 #[derive(Debug, Serialize, Deserialize)]
@@ -72,19 +99,32 @@ pub struct DataDecryptionResponse {
     pub data: DecryptedData,
 }
 
-#[derive(Debug)]
-pub struct EncryptedData {
-    pub data: Secret<Vec<u8>>,
+#[derive(Debug, Clone)]
+pub struct EncryptedData(Secret<Vec<u8>>);
+
+impl EncryptedData {
+    pub fn from_secret(data: Secret<Vec<u8>>) -> Self {
+        Self(data)
+    }
+    pub fn inner(self) -> Secret<Vec<u8>> {
+        self.0
+    }
 }
 
-impl Serialize for EncryptedData {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        let data = String::from_utf8(self.data.peek().clone()).map_err(ser::Error::custom)?;
-        serializer.serialize_str(data.as_str())
-    }
+pub fn serialize_encryption_data<S>(
+    encrypted_data: &EncryptedData,
+    serializer: S,
+) -> Result<S::Ok, S::Error>
+where
+    S: Serializer,
+{
+    let encrypted_data = encrypted_data.clone().inner().expose();
+    // Since old encrypted data doesn't have version prefixed to it, it would fail to get encoded as String.
+    // If so, we manually prefix it with v1 as version and BASE64 encode the data.
+    let encoded_data = String::from_utf8(encrypted_data.clone())
+        .unwrap_or(format!("v1:{}", BASE64_ENGINE.encode(encrypted_data)));
+
+    serializer.serialize_str(encoded_data.as_str())
 }
 
 impl<'de> Deserialize<'de> for EncryptedData {
@@ -105,9 +145,7 @@ impl<'de> Deserialize<'de> for EncryptedData {
             where
                 E: de::Error,
             {
-                Ok(EncryptedData {
-                    data: Secret::new(value.as_bytes().to_vec()),
-                })
+                Ok(EncryptedData(Secret::new(value.as_bytes().to_vec())))
             }
         }
 
@@ -119,11 +157,21 @@ impl<'de> Deserialize<'de> for EncryptedData {
 pub struct DecryptedData(Secret<Vec<u8>>);
 
 impl DecryptedData {
-    pub fn from_data(data: Secret<Vec<u8>>) -> Self {
+    pub fn from_secret(data: Secret<Vec<u8>>) -> Self {
         Self(data)
     }
     pub fn inner(self) -> Secret<Vec<u8>> {
         self.0
+    }
+    pub fn from_value<T>(data: &T) -> Result<Self, error::ContainerError<error::ApiError>>
+    where
+        T: Serialize,
+    {
+        Ok(Self(
+            serde_json::to_vec(data)
+                .change_error(error::ApiError::EncodingError)?
+                .into(),
+        ))
     }
 }
 

--- a/src/crypto/keymanager/types.rs
+++ b/src/crypto/keymanager/types.rs
@@ -49,26 +49,26 @@ impl DataKeyTransferRequest {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct EncryptDataRequest {
+pub struct DataEncryptionRequest {
     #[serde(flatten)]
     pub identifier: Identifier,
     pub data: DecryptedData,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct EncryptDateResponse {
+pub struct DateEncryptionResponse {
     pub data: EncryptedData,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DecryptDataRequest {
+pub struct DataDecryptionRequest {
     #[serde(flatten)]
     pub identifier: Identifier,
     pub data: EncryptedData,
 }
 
 #[derive(Debug, Serialize, Deserialize)]
-pub struct DecryptDataResponse {
+pub struct DataDecryptionResponse {
     pub data: DecryptedData,
 }
 

--- a/src/crypto/keymanager/types.rs
+++ b/src/crypto/keymanager/types.rs
@@ -1,0 +1,183 @@
+use std::fmt;
+
+use crate::{
+    crypto,
+    storage::{consts, utils},
+};
+use base64::Engine;
+use masking::{PeekInterface, Secret};
+use serde::{
+    de::{self, Unexpected, Visitor},
+    ser, Deserialize, Deserializer, Serialize,
+};
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct DataKeyCreateRequest {
+    #[serde(flatten)]
+    pub identifier: Identifier,
+}
+
+impl DataKeyCreateRequest {
+    pub fn create_request() -> Self {
+        Self {
+            identifier: Identifier::Entity(utils::generate_id(consts::ID_LENGTH)),
+        }
+    }
+}
+
+#[derive(Debug, Deserialize, Serialize)]
+pub struct DataKeyCreateResponse {
+    #[serde(flatten)]
+    pub identifier: Identifier,
+    pub key_version: String,
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+pub struct DataKeyTransferRequest {
+    #[serde(flatten)]
+    pub identifier: Identifier,
+    pub key: String,
+}
+
+impl DataKeyTransferRequest {
+    pub fn create_request(key: Vec<u8>) -> Self {
+        Self {
+            identifier: Identifier::Entity(utils::generate_id(consts::ID_LENGTH)),
+            key: crypto::consts::BASE64_ENGINE.encode(key),
+        }
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+pub struct EncryptDataRequest {
+    #[serde(flatten)]
+    pub identifier: Identifier,
+    pub data: DecryptedData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct EncryptDateResponse {
+    pub data: EncryptedData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DecryptDataRequest {
+    #[serde(flatten)]
+    pub identifier: Identifier,
+    pub data: EncryptedData,
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+pub struct DecryptDataResponse {
+    pub data: DecryptedData,
+}
+
+#[derive(Debug)]
+pub struct EncryptedData {
+    pub data: Secret<Vec<u8>>,
+}
+
+impl Serialize for EncryptedData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let data = String::from_utf8(self.data.peek().clone()).map_err(ser::Error::custom)?;
+        serializer.serialize_str(data.as_str())
+    }
+}
+
+impl<'de> Deserialize<'de> for EncryptedData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct EncryptedDataVisitor;
+
+        impl<'de> Visitor<'de> for EncryptedDataVisitor {
+            type Value = EncryptedData;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("string of the format {version}:{base64_encoded_data}'")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<EncryptedData, E>
+            where
+                E: de::Error,
+            {
+                Ok(EncryptedData {
+                    data: Secret::new(value.as_bytes().to_vec()),
+                })
+            }
+        }
+
+        deserializer.deserialize_str(EncryptedDataVisitor)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct DecryptedData(Secret<Vec<u8>>);
+
+impl DecryptedData {
+    pub fn from_data(data: Secret<Vec<u8>>) -> Self {
+        Self(data)
+    }
+    pub fn inner(self) -> Secret<Vec<u8>> {
+        self.0
+    }
+}
+
+impl Serialize for DecryptedData {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        let data = crypto::consts::BASE64_ENGINE.encode(self.0.peek());
+        serializer.serialize_str(&data)
+    }
+}
+
+impl<'de> Deserialize<'de> for DecryptedData {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: Deserializer<'de>,
+    {
+        struct DecryptedDataVisitor;
+
+        impl<'de> Visitor<'de> for DecryptedDataVisitor {
+            type Value = DecryptedData;
+
+            fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                formatter.write_str("string of the format {version}:{base64_encoded_data}'")
+            }
+
+            fn visit_str<E>(self, value: &str) -> Result<DecryptedData, E>
+            where
+                E: de::Error,
+            {
+                let dec_data = crypto::consts::BASE64_ENGINE.decode(value).map_err(|err| {
+                    let err = err.to_string();
+                    E::invalid_value(Unexpected::Str(value), &err.as_str())
+                })?;
+
+                Ok(DecryptedData(dec_data.into()))
+            }
+        }
+
+        deserializer.deserialize_str(DecryptedDataVisitor)
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
+#[serde(tag = "data_identifier", content = "key_identifier")]
+pub enum Identifier {
+    Entity(String),
+}
+
+impl Identifier {
+    pub fn get_identifier(&self) -> String {
+        match self {
+            Self::Entity(identifier) => identifier.clone(),
+        }
+    }
+}

--- a/src/error.rs
+++ b/src/error.rs
@@ -28,33 +28,6 @@ pub enum ConfigurationError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum ApiClientError {
-    #[error("Client construction failed")]
-    ClientConstructionFailed,
-    #[error("Header map construction failed")]
-    HeaderMapConstructionFailed,
-    #[error("Identity parsing failed: {0:?}")]
-    IdentityParseFailed(reqwest::Error),
-    #[error("Certificate parsing failed for {client}: {error:?}")]
-    CertificateParseFailed {
-        client: &'static str,
-        error: reqwest::Error,
-    },
-    #[error("URL encoding of request failed")]
-    UrlEncodingFailed,
-    #[error("Failed to send request to {service}: {message}")]
-    RequestNotSent { service: String, message: String },
-    #[error("Response Decoding failed")]
-    ResponseDecodingFailed,
-    #[error("Bad request received {0:?}")]
-    BadRequest(bytes::Bytes),
-    #[error("Unexpected Error occurred while calling the api client")]
-    Unexpected(bytes::Bytes),
-    #[error("Internal Server Error Received {0:?}")]
-    InternalServerError(bytes::Bytes),
-}
-
-#[derive(Debug, thiserror::Error)]
 pub enum CryptoError {
     #[error("failed while serializing with serde_json")]
     SerdeJsonError(#[from] serde_json::Error),
@@ -193,33 +166,115 @@ pub enum KmsError {
 }
 
 #[derive(Debug, thiserror::Error)]
-pub enum KeyManagerError {
-    #[error("Failed to construct header from the given value")]
-    FailedtoConstructHeader,
-    #[error("Failed to send request to Keymanager")]
-    RequestNotSent(String),
-    #[error("URL encoding of request failed")]
-    UrlEncodingFailed,
-    #[error("Failed to build the reqwest client ")]
+pub enum ApiClientError {
+    #[error("Failed to construct api client")]
     ClientConstructionFailed,
-    #[error("Failed to send the request to Keymanager")]
-    RequestSendFailed,
-    #[error("Internal Server Error Received {0:?}")]
-    InternalServerError(bytes::Bytes),
-    #[error("Bad request received {0:?}")]
-    BadRequest(bytes::Bytes),
-    #[error("Unexpected Error occurred while calling the KeyManager")]
-    Unexpected(bytes::Bytes),
-    #[error("Response Decoding failed")]
+    #[error("Failed to construct Header map")]
+    HeaderMapConstructionFailed,
+    #[error("Failed to parse Identity")]
+    IdentityParseFailed,
+    #[error("Failed to parse Certificate of {service}")]
+    CertificateParseFailed { service: &'static str },
+    #[error("Failed to encode request URL")]
+    UrlEncodingFailed,
+    #[error("Failed to send api request")]
+    RequestNotSent,
+    #[error("Failed to decode response")]
     ResponseDecodingFailed,
-    #[error("Failed to add key to the KeyManager")]
+    #[error("Received bad request: {0:?}")]
+    BadRequest(bytes::Bytes),
+    #[error("Unexpected error occurred: {0:?}")]
+    Unexpected(bytes::Bytes),
+    #[error("Received internal server error {0:?}")]
+    InternalServerError(bytes::Bytes),
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum KeyManagerError {
+    #[error("Failed to add key to the Key manager")]
     KeyAddFailed,
-    #[error("Failed to transfer the key to the KeyManager")]
+    #[error("Failed to transfer the key to the Key manager")]
     KeyTransferFailed,
-    #[error("Failed to Encrypt the data in the KeyManager")]
+    #[error("Failed to encrypt the data in the Key manager")]
     EncryptionFailed,
-    #[error("Failed to Decrypt the data in the KeyManager")]
+    #[error("Failed to decrypt the data in the Key manager")]
     DecryptionFailed,
+    #[error("Failed while performing db operation on entity")]
+    DbError,
+    #[error("Response decoding failed")]
+    ResponseDecodingFailed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataKeyCreationError {
+    #[error("Failed to send the request to Key manager")]
+    RequestSendFailed,
+    #[error("Response decoding failed")]
+    ResponseDecodingFailed,
+    #[error("Received internal server error")]
+    InternalServerError,
+    #[error("Unexpected error occurred while calling the Key manager")]
+    Unexpected,
+    #[error("Received bad request")]
+    BadRequest,
+    #[error("Failed while parsing certificates")]
+    CertificateParseFailed,
+    #[error("Failed while constructing client request")]
+    RequestConstructionFailed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataKeyTransferError {
+    #[error("Failed to send the request to Key manager")]
+    RequestSendFailed,
+    #[error("Response decoding failed")]
+    ResponseDecodingFailed,
+    #[error("Received internal server error")]
+    InternalServerError,
+    #[error("Unexpected error occurred while calling the Key manager")]
+    Unexpected,
+    #[error("Bad request received")]
+    BadRequest,
+    #[error("Failed while parsing certificates")]
+    CertificateParseFailed,
+    #[error("Failed while constructing client request")]
+    RequestConstructionFailed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataEncryptionError {
+    #[error("Failed to send the request to Key manager")]
+    RequestSendFailed,
+    #[error("Response decoding failed")]
+    ResponseDecodingFailed,
+    #[error("Received internal server error")]
+    InternalServerError,
+    #[error("Unexpected error occurred while calling the Key manager")]
+    Unexpected,
+    #[error("Received bad request")]
+    BadRequest,
+    #[error("Failed while parsing certificates")]
+    CertificateParseFailed,
+    #[error("Failed while constructing client request")]
+    RequestConstructionFailed,
+}
+
+#[derive(Debug, thiserror::Error)]
+pub enum DataDecryptionError {
+    #[error("Failed to send the request to Key manager")]
+    RequestSendFailed,
+    #[error("Response decoding failed")]
+    ResponseDecodingFailed,
+    #[error("Received internal server error")]
+    InternalServerError,
+    #[error("Unexpected error occurred while calling the Key manager")]
+    Unexpected,
+    #[error("Received bad request")]
+    BadRequest,
+    #[error("Failed while parsing certificates")]
+    CertificateParseFailed,
+    #[error("Failed while constructing client request")]
+    RequestConstructionFailed,
 }
 
 /// Error code constants.

--- a/src/error/container.rs
+++ b/src/error/container.rs
@@ -79,6 +79,7 @@ where
     E1: error_stack::Context,
     E2: error_stack::Context,
 {
+    #[track_caller]
     fn change_error(self, error: E2) -> Result<T, ContainerError<E2>> {
         match self {
             Ok(value) => Ok(value),

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -76,6 +76,20 @@ pub enum FingerprintDBError {
     EncodingError,
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum EntityDBError {
+    #[error("Error while connecting to database")]
+    DBError,
+    #[error("Error while finding element in the database")]
+    DBFilterError,
+    #[error("Error while inserting element in the database")]
+    DBInsertError,
+    #[error("Unpredictable error occurred")]
+    UnknownError,
+    #[error("Element not found in database")]
+    NotFoundError,
+}
+
 pub trait NotFoundError {
     fn is_not_found(&self) -> bool;
 }
@@ -83,5 +97,11 @@ pub trait NotFoundError {
 impl NotFoundError for super::ContainerError<MerchantDBError> {
     fn is_not_found(&self) -> bool {
         matches!(self.error.current_context(), MerchantDBError::NotFoundError)
+    }
+}
+
+impl NotFoundError for super::ContainerError<EntityDBError> {
+    fn is_not_found(&self) -> bool {
+        matches!(self.error.current_context(), EntityDBError::NotFoundError)
     }
 }

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -234,3 +234,48 @@ impl<'a> From<&'a super::CryptoError> for super::ApiError {
         }
     }
 }
+
+error_transform!(super::StorageError => super::EntityDBError);
+impl<'a> From<&'a super::StorageError> for super::EntityDBError {
+    fn from(value: &'a super::StorageError) -> Self {
+        match value {
+            super::StorageError::DBPoolError | super::StorageError::PoolClientFailure => {
+                Self::DBError
+            }
+            super::StorageError::FindError => Self::DBFilterError,
+            super::StorageError::NotFoundError => Self::NotFoundError,
+            super::StorageError::DecryptionError
+            | super::StorageError::EncryptionError
+            | super::StorageError::DeleteError => Self::UnknownError,
+            super::StorageError::InsertError => Self::DBInsertError,
+        }
+    }
+}
+
+error_transform!(super::CryptoError => super::EntityDBError);
+impl<'a> From<&'a super::CryptoError> for super::EntityDBError {
+    fn from(value: &'a super::CryptoError) -> Self {
+        match value {
+            super::CryptoError::SerdeJsonError(_)
+            | super::CryptoError::JWError(_)
+            | super::CryptoError::InvalidData(_)
+            | super::CryptoError::NotImplemented
+            | super::CryptoError::EncryptionError
+            | super::CryptoError::DecryptionError
+            | super::CryptoError::EncodingError(_) => Self::UnknownError,
+        }
+    }
+}
+
+error_transform!(super::EntityDBError => super::ApiError);
+impl<'a> From<&'a super::EntityDBError> for super::ApiError {
+    fn from(value: &'a super::EntityDBError) -> Self {
+        match value {
+            super::EntityDBError::DBError => Self::DatabaseError,
+            super::EntityDBError::DBFilterError => Self::RetrieveDataFailed("entity"),
+            super::EntityDBError::DBInsertError => Self::DatabaseInsertFailed("entity"),
+            super::EntityDBError::UnknownError => Self::UnknownError,
+            super::EntityDBError::NotFoundError => Self::NotFoundError,
+        }
+    }
+}

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -279,3 +279,172 @@ impl<'a> From<&'a super::EntityDBError> for super::ApiError {
         }
     }
 }
+
+error_transform!(super::KeyManagerError => super::ApiError);
+impl<'a> From<&'a super::KeyManagerError> for super::ApiError {
+    fn from(value: &'a super::KeyManagerError) -> Self {
+        match value {
+            super::KeyManagerError::KeyAddFailed => {
+                Self::KeyManagerError("Failed to add key to the Key manager")
+            }
+            super::KeyManagerError::KeyTransferFailed => {
+                Self::KeyManagerError("Failed to transfer the key to the Key manager")
+            }
+            super::KeyManagerError::EncryptionFailed => {
+                Self::KeyManagerError("Failed to encrypt the data in the Key manager")
+            }
+            super::KeyManagerError::DecryptionFailed => {
+                Self::KeyManagerError("Failed to decrypt the data in the Key manager")
+            }
+            super::KeyManagerError::DbError => Self::KeyManagerError("Database error"),
+            super::KeyManagerError::ResponseDecodingFailed => {
+                Self::KeyManagerError("Failed to deserialize from bytes")
+            }
+        }
+    }
+}
+
+error_transform!(super::EntityDBError => super::KeyManagerError);
+impl<'a> From<&'a super::EntityDBError> for super::KeyManagerError {
+    fn from(value: &'a super::EntityDBError) -> Self {
+        match value {
+            super::EntityDBError::DBError
+            | super::EntityDBError::DBFilterError
+            | super::EntityDBError::DBInsertError
+            | super::EntityDBError::UnknownError
+            | super::EntityDBError::NotFoundError => Self::DbError,
+        }
+    }
+}
+
+error_transform!(super::ApiClientError => super::DataKeyCreationError);
+impl<'a> From<&'a super::ApiClientError> for super::DataKeyCreationError {
+    fn from(value: &'a super::ApiClientError) -> Self {
+        match value {
+            super::ApiClientError::ClientConstructionFailed
+            | super::ApiClientError::Unexpected(_) => Self::Unexpected,
+            super::ApiClientError::HeaderMapConstructionFailed
+            | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
+            super::ApiClientError::IdentityParseFailed
+            | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
+            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
+            super::ApiClientError::BadRequest(_) => Self::BadRequest,
+            super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
+        }
+    }
+}
+
+error_transform!(super::DataKeyCreationError => super::KeyManagerError);
+impl<'a> From<&'a super::DataKeyCreationError> for super::KeyManagerError {
+    fn from(value: &'a super::DataKeyCreationError) -> Self {
+        match value {
+            super::DataKeyCreationError::RequestSendFailed
+            | super::DataKeyCreationError::ResponseDecodingFailed
+            | super::DataKeyCreationError::InternalServerError
+            | super::DataKeyCreationError::Unexpected
+            | super::DataKeyCreationError::BadRequest
+            | super::DataKeyCreationError::CertificateParseFailed
+            | super::DataKeyCreationError::RequestConstructionFailed => Self::KeyAddFailed,
+        }
+    }
+}
+
+error_transform!(super::ApiClientError => super::DataKeyTransferError);
+impl<'a> From<&'a super::ApiClientError> for super::DataKeyTransferError {
+    fn from(value: &'a super::ApiClientError) -> Self {
+        match value {
+            super::ApiClientError::ClientConstructionFailed
+            | super::ApiClientError::Unexpected(_) => Self::Unexpected,
+            super::ApiClientError::HeaderMapConstructionFailed
+            | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
+            super::ApiClientError::IdentityParseFailed
+            | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
+            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
+            super::ApiClientError::BadRequest(_) => Self::BadRequest,
+            super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
+        }
+    }
+}
+
+error_transform!(super::DataKeyTransferError => super::KeyManagerError);
+impl<'a> From<&'a super::DataKeyTransferError> for super::KeyManagerError {
+    fn from(value: &'a super::DataKeyTransferError) -> Self {
+        match value {
+            super::DataKeyTransferError::RequestSendFailed
+            | super::DataKeyTransferError::ResponseDecodingFailed
+            | super::DataKeyTransferError::InternalServerError
+            | super::DataKeyTransferError::Unexpected
+            | super::DataKeyTransferError::BadRequest
+            | super::DataKeyTransferError::CertificateParseFailed
+            | super::DataKeyTransferError::RequestConstructionFailed => Self::KeyTransferFailed,
+        }
+    }
+}
+
+error_transform!(super::DataEncryptionError => super::KeyManagerError);
+impl<'a> From<&'a super::DataEncryptionError> for super::KeyManagerError {
+    fn from(value: &'a super::DataEncryptionError) -> Self {
+        match value {
+            super::DataEncryptionError::RequestSendFailed
+            | super::DataEncryptionError::ResponseDecodingFailed
+            | super::DataEncryptionError::InternalServerError
+            | super::DataEncryptionError::Unexpected
+            | super::DataEncryptionError::BadRequest
+            | super::DataEncryptionError::CertificateParseFailed
+            | super::DataEncryptionError::RequestConstructionFailed => Self::EncryptionFailed,
+        }
+    }
+}
+
+error_transform!(super::ApiClientError => super::DataEncryptionError);
+impl<'a> From<&'a super::ApiClientError> for super::DataEncryptionError {
+    fn from(value: &'a super::ApiClientError) -> Self {
+        match value {
+            super::ApiClientError::ClientConstructionFailed
+            | super::ApiClientError::Unexpected(_) => Self::Unexpected,
+            super::ApiClientError::HeaderMapConstructionFailed
+            | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
+            super::ApiClientError::IdentityParseFailed
+            | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
+            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
+            super::ApiClientError::BadRequest(_) => Self::BadRequest,
+            super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
+        }
+    }
+}
+
+error_transform!(super::DataDecryptionError => super::KeyManagerError);
+impl<'a> From<&'a super::DataDecryptionError> for super::KeyManagerError {
+    fn from(value: &'a super::DataDecryptionError) -> Self {
+        match value {
+            super::DataDecryptionError::RequestSendFailed
+            | super::DataDecryptionError::ResponseDecodingFailed
+            | super::DataDecryptionError::InternalServerError
+            | super::DataDecryptionError::Unexpected
+            | super::DataDecryptionError::BadRequest
+            | super::DataDecryptionError::CertificateParseFailed
+            | super::DataDecryptionError::RequestConstructionFailed => Self::DecryptionFailed,
+        }
+    }
+}
+
+error_transform!(super::ApiClientError => super::DataDecryptionError);
+impl<'a> From<&'a super::ApiClientError> for super::DataDecryptionError {
+    fn from(value: &'a super::ApiClientError) -> Self {
+        match value {
+            super::ApiClientError::ClientConstructionFailed
+            | super::ApiClientError::Unexpected(_) => Self::Unexpected,
+            super::ApiClientError::HeaderMapConstructionFailed
+            | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
+            super::ApiClientError::IdentityParseFailed
+            | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
+            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
+            super::ApiClientError::BadRequest(_) => Self::BadRequest,
+            super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
+        }
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+pub mod api_client;
 pub mod app;
 pub mod config;
 pub mod crypto;

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -117,10 +117,7 @@ pub async fn add_card(
                 merchant.enc_key.clone().expose(),
             ),
         )
-        .await
-        .change_error(error::ApiError::KeyManagerError(
-            "Failed to transfer key to key manager",
-        ))?;
+        .await?;
     }
 
     let merchant_dek = GcmAes256::new(merchant.enc_key.expose());

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -115,7 +115,7 @@ pub async fn decrypt(
             aes_decrypt_custodian_key(&mut tenant_config, inner_key1, inner_key2).await?;
 
             let tenant_app_state = TenantAppState::new(
-                global_app_state.global_config.clone(),
+                &global_app_state.global_config,
                 tenant_config,
                 global_app_state.api_client.clone(),
             )

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -114,12 +114,15 @@ pub async fn decrypt(
             );
             aes_decrypt_custodian_key(&mut tenant_config, inner_key1, inner_key2).await?;
 
-            let tenant_app_state =
-                TenantAppState::new(global_app_state.global_config.clone(), tenant_config)
-                    .await
-                    .change_context(error::ApiError::TenantError(
-                        "Failed while creating AppState for tenant",
-                    ))?;
+            let tenant_app_state = TenantAppState::new(
+                global_app_state.global_config.clone(),
+                tenant_config,
+                global_app_state.api_client.clone(),
+            )
+            .await
+            .change_context(error::ApiError::TenantError(
+                "Failed while creating AppState for tenant",
+            ))?;
 
             global_app_state.set_app_state(tenant_app_state).await;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -103,6 +103,12 @@ impl Cacheable<types::Fingerprint> for Storage {
     type Value = types::Fingerprint;
 }
 
+#[cfg(feature = "caching")]
+impl Cacheable<types::Entity> for Storage {
+    type Key = String;
+    type Value = types::Entity;
+}
+
 ///
 /// MerchantInterface:
 ///
@@ -220,4 +226,25 @@ pub(crate) trait FingerprintInterface {
         card: types::CardNumber,
         hash_key: Secret<String>,
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>>;
+}
+
+///
+/// EntityInterface:
+///
+/// Interface providing functionality to interface with the entity table in database
+pub(crate) trait EntityInterface {
+    type Error;
+
+    /// find merchant from merchant table with `merchant_id` with key as master key
+    async fn find_by_entity_id(
+        &self,
+        entity_id: &str,
+    ) -> Result<types::Entity, ContainerError<Self::Error>>;
+
+    /// Insert a new merchant in the database by encrypting the dek with `master_key`
+    async fn insert_entity(
+        &self,
+        entity_id: &str,
+        identifier: &str,
+    ) -> Result<types::Entity, ContainerError<Self::Error>>;
 }

--- a/src/storage/caching.rs
+++ b/src/storage/caching.rs
@@ -10,19 +10,22 @@ pub struct Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     inner: T,
     merchant_cache: Cache<T, types::Merchant>,
     hash_table_cache: Cache<T, types::HashTable>,
     fingerprint_cache: Cache<T, types::Fingerprint>,
+    entity_cache: Cache<T, types::Entity>,
 }
 
 impl<T> std::ops::Deref for Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     type Target = T;
 
@@ -55,7 +58,8 @@ impl<T> GetCache<T, types::Merchant> for Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     fn get_cache(&self) -> &Cache<T, types::Merchant> {
         &self.merchant_cache
@@ -66,7 +70,8 @@ impl<T> GetCache<T, types::HashTable> for Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     fn get_cache(&self) -> &Cache<T, types::HashTable> {
         &self.hash_table_cache
@@ -77,10 +82,23 @@ impl<T> GetCache<T, types::Fingerprint> for Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     fn get_cache(&self) -> &Cache<T, types::Fingerprint> {
         &self.fingerprint_cache
+    }
+}
+
+impl<T> GetCache<T, types::Entity> for Caching<T>
+where
+    T: super::Cacheable<types::Merchant>
+        + super::Cacheable<types::HashTable>
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
+{
+    fn get_cache(&self) -> &Cache<T, types::Entity> {
+        &self.entity_cache
     }
 }
 
@@ -88,7 +106,8 @@ impl<T> Caching<T>
 where
     T: super::Cacheable<types::Merchant>
         + super::Cacheable<types::HashTable>
-        + super::Cacheable<types::Fingerprint>,
+        + super::Cacheable<types::Fingerprint>
+        + super::Cacheable<types::Entity>,
 {
     #[inline(always)]
     pub async fn lookup<U>(
@@ -125,16 +144,19 @@ where
             let merchant_cache = new_cache::<T, types::Merchant>(config, "merchant");
             let hash_table_cache = new_cache::<T, types::HashTable>(config, "hash_table");
             let fingerprint_cache = new_cache::<T, types::Fingerprint>(config, "fingerprint");
+            let entity_cache = new_cache::<T, types::Entity>(config, "entity");
             Self {
                 inner,
                 merchant_cache,
                 hash_table_cache,
                 fingerprint_cache,
+                entity_cache,
             }
         }
     }
 }
 
+pub mod entity;
 pub mod fingerprint;
 pub mod hash_table;
 pub mod merchant;

--- a/src/storage/caching/entity.rs
+++ b/src/storage/caching/entity.rs
@@ -1,0 +1,46 @@
+use crate::{
+    error::{ContainerError, NotFoundError},
+    storage::{self, types},
+};
+
+impl<T> storage::EntityInterface for super::Caching<T>
+where
+    T: storage::EntityInterface
+        + storage::Cacheable<types::Entity, Key = String, Value = types::Entity>
+        + storage::Cacheable<types::Merchant>
+        + storage::Cacheable<types::HashTable>
+        + storage::Cacheable<types::Fingerprint>
+        + Sync
+        + Send,
+    ContainerError<<T as storage::EntityInterface>::Error>: NotFoundError,
+{
+    type Error = T::Error;
+
+    async fn find_by_entity_id(
+        &self,
+        entity_id: &str,
+    ) -> Result<types::Entity, ContainerError<Self::Error>> {
+        let entity_idd = entity_id.to_string();
+        let cached_data = self.lookup::<types::Entity>(entity_idd.clone()).await;
+        match cached_data {
+            Some(value) => Ok(value),
+            None => {
+                let output = self.inner.find_by_entity_id(entity_id).await?;
+                self.cache_data::<types::Entity>(output.entity_id.to_string(), output.clone())
+                    .await;
+                Ok(output)
+            }
+        }
+    }
+
+    async fn insert_entity(
+        &self,
+        entity_id: &str,
+        identifier: &str,
+    ) -> Result<types::Entity, ContainerError<Self::Error>> {
+        let output = self.inner.insert_entity(entity_id, identifier).await?;
+        self.cache_data::<types::Entity>(entity_id.to_string(), output.clone())
+            .await;
+        Ok(output)
+    }
+}

--- a/src/storage/caching/fingerprint.rs
+++ b/src/storage/caching/fingerprint.rs
@@ -11,6 +11,7 @@ where
         + storage::Cacheable<types::Fingerprint, Key = Vec<u8>, Value = types::Fingerprint>
         + storage::Cacheable<types::Merchant>
         + storage::Cacheable<types::HashTable>
+        + storage::Cacheable<types::Entity>
         + Sync
         + Send,
 {

--- a/src/storage/caching/hash_table.rs
+++ b/src/storage/caching/hash_table.rs
@@ -9,6 +9,7 @@ where
         + storage::Cacheable<types::HashTable, Key = Vec<u8>, Value = types::HashTable>
         + storage::Cacheable<types::Merchant>
         + storage::Cacheable<types::Fingerprint>
+        + storage::Cacheable<types::Entity>
         + Sync
         + Send,
 {

--- a/src/storage/caching/merchant.rs
+++ b/src/storage/caching/merchant.rs
@@ -12,6 +12,7 @@ where
         + storage::Cacheable<types::Merchant, Key = String, Value = types::Merchant>
         + storage::Cacheable<types::HashTable>
         + storage::Cacheable<types::Fingerprint>
+        + storage::Cacheable<types::Entity>
         + Sync
         + Send,
     ContainerError<<T as storage::MerchantInterface>::Error>: NotFoundError,

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -8,3 +8,8 @@ pub(crate) const ALPHABETS: [char; 62] = [
 
 /// Number of characters in a generated ID
 pub const ID_LENGTH: usize = 20;
+
+/// Header Constants
+pub mod headers {
+    pub const CONTENT_TYPE: &str = "Content-Type";
+}

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -105,6 +105,14 @@ pub struct Fingerprint {
     pub card_fingerprint: Secret<String>,
 }
 
+#[derive(Debug, Clone, Identifiable, Queryable)]
+#[diesel(table_name = schema::entity)]
+pub struct Entity {
+    pub id: i32,
+    pub entity_id: String,
+    pub enc_key_id: String,
+}
+
 #[derive(Debug, serde::Serialize, serde::Deserialize, Eq, PartialEq)]
 pub struct CardNumber(StrongSecret<String>);
 
@@ -137,6 +145,13 @@ impl std::ops::Deref for CardNumber {
 pub(super) struct FingerprintTableNew {
     pub fingerprint_hash: Secret<Vec<u8>>,
     pub fingerprint_id: Secret<String>,
+}
+
+#[derive(Debug, Insertable)]
+#[diesel(table_name = schema::entity)]
+pub(super) struct EntityTableNew {
+    pub entity_id: String,
+    pub enc_key_id: String,
 }
 
 #[derive(Debug, Insertable)]

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -56,13 +56,10 @@ impl GlobalAppState {
                     let tenant_config =
                         TenantConfig::from_global_config(&global_config, tenant_id.clone());
                     #[allow(clippy::expect_used)]
-                    let tenant_app_state = TenantAppState::new(
-                        global_config.clone(),
-                        tenant_config,
-                        api_client.clone(),
-                    )
-                    .await
-                    .expect("Failed while configuring AppState for tenants");
+                    let tenant_app_state =
+                        TenantAppState::new(&global_config, tenant_config, api_client.clone())
+                            .await
+                            .expect("Failed while configuring AppState for tenants");
                     tenants_app_state.insert(tenant_id, Arc::new(tenant_app_state));
                 }
                 tenants_app_state


### PR DESCRIPTION
This PR integrates secret manager and makes use of it to store the entity dek.
Keeping in mind about the old dek's, this PR for now calls secret manager to store dek, only when new merchant hits add request. This is done to keep the number of merchant dek's to be migrated in future fixed. 
During add request, if new merchant, create a merchant dek in merchant table and also call secret manager to transfer the created dek to the service.