### PR TITLE
chore: add support for schema as a key in tenant secrets

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -54,7 +54,7 @@ Sau7H1Bhzy5G7rwt05LNpU6nFcAGVaZtzl4/+FYfYIulubYjuSEh72yuBHHyvi1/
 """
 
 [tenant_secrets]
-public = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
+hyperswitch = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Z/K0JWds8iHhWCa+rj0
 rhOQX1nVs/ArQ1D0vh3UlSPR2vZUTrkdP7i3amv4d2XDC+3+5/YWExTkpxqnfl1T
@@ -64,7 +64,7 @@ zawslZfgqD0eov4FjzBMoA19yNtlVLLf6kOkLcFQjTKXJLP1tLflLUBPTg8fm9wg
 APK2BjMQ2AMkUxx0ubbtw/9CeJ+bFWrqGnEhlvfDMlyAV77sAiIdQ4mXs3TLcLb/
 AQIDAQAB
 -----END PUBLIC KEY-----
-""" }
+""", schema = "public" }
 
 [key_manager]
 url = "http://localhost:5000"

--- a/config/development.toml
+++ b/config/development.toml
@@ -54,7 +54,7 @@ Sau7H1Bhzy5G7rwt05LNpU6nFcAGVaZtzl4/+FYfYIulubYjuSEh72yuBHHyvi1/
 """
 
 [tenant_secrets]
-"public" = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
+public = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Z/K0JWds8iHhWCa+rj0
 rhOQX1nVs/ArQ1D0vh3UlSPR2vZUTrkdP7i3amv4d2XDC+3+5/YWExTkpxqnfl1T

--- a/src/app.rs
+++ b/src/app.rs
@@ -40,12 +40,6 @@ impl TenantAppState {
     ///
     /// Construct new app state with configuration
     ///
-    /// # Panics
-    ///
-    /// - If the master key cannot be parsed as a string
-    /// - If the public/private key cannot be parsed as a string after kms decrypt
-    /// - If the database password cannot be parsed as a string after kms decrypt
-    ///
     pub async fn new(
         global_config: &GlobalConfig,
         tenant_config: TenantConfig,

--- a/src/app.rs
+++ b/src/app.rs
@@ -47,9 +47,7 @@ impl TenantAppState {
     ) -> error_stack::Result<Self, error::ConfigurationError> {
         let db = storage::Storage::new(
             &global_config.database,
-            &tenant_config
-                .tenant_secrets
-                .schema,
+            &tenant_config.tenant_secrets.schema,
         )
         .await
         .map(

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,15 +45,20 @@ impl TenantAppState {
         tenant_config: TenantConfig,
         api_client: ApiClient,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
-        let db = storage::Storage::new(&global_config.database, &tenant_config.schema)
-            .await
-            .map(
-                #[cfg(feature = "caching")]
-                Caching::implement_cache(&global_config.cache),
-                #[cfg(not(feature = "caching"))]
-                std::convert::identity,
-            )
-            .change_context(error::ConfigurationError::DatabaseError)?;
+        let db = storage::Storage::new(
+            &global_config.database,
+            &tenant_config
+                .tenant_secrets
+                .schema,
+        )
+        .await
+        .map(
+            #[cfg(feature = "caching")]
+            Caching::implement_cache(&global_config.cache),
+            #[cfg(not(feature = "caching"))]
+            std::convert::identity,
+        )
+        .change_context(error::ConfigurationError::DatabaseError)?;
 
         Ok(Self {
             db,

--- a/src/app.rs
+++ b/src/app.rs
@@ -45,7 +45,7 @@ impl TenantAppState {
         tenant_config: TenantConfig,
         api_client: ApiClient,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
-        let db = storage::Storage::new(&global_config.database, &tenant_config.tenant_id)
+        let db = storage::Storage::new(&global_config.database, &tenant_config.schema)
             .await
             .map(
                 #[cfg(feature = "caching")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,6 +43,7 @@ pub struct TenantConfig {
     pub locker_secrets: Secrets,
     pub tenant_secrets: TenantSecrets,
     pub key_manager: KeyManagerConfig,
+    pub schema: String,
 }
 
 impl TenantConfig {
@@ -51,7 +52,11 @@ impl TenantConfig {
     ///
     /// Never, as tenant_id would already be validated from [`crate::custom_extractors::TenantId`] custom extractor
     ///
-    pub fn from_global_config(global_config: &GlobalConfig, tenant_id: String) -> Self {
+    pub fn from_global_config(
+        global_config: &GlobalConfig,
+        tenant_id: String,
+        schema: Option<String>,
+    ) -> Self {
         Self {
             tenant_id: tenant_id.clone(),
             locker_secrets: global_config.secrets.clone(),
@@ -62,6 +67,7 @@ impl TenantConfig {
                 .cloned()
                 .unwrap(),
             key_manager: global_config.key_manager.clone(),
+            schema: schema.unwrap_or(tenant_id),
         }
     }
 }
@@ -113,6 +119,9 @@ pub struct TenantSecrets {
     pub master_key: Vec<u8>,
     #[cfg(feature = "middleware")]
     pub public_key: masking::Secret<String>,
+
+    /// schema name for the tenant (defaults to tenant_id)
+    pub schema: Option<String>,
 }
 
 fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/src/config.rs
+++ b/src/config.rs
@@ -51,10 +51,7 @@ impl TenantConfig {
     ///
     /// Never, as tenant_id would already be validated from [`crate::custom_extractors::TenantId`] custom extractor
     ///
-    pub fn from_global_config(
-        global_config: &GlobalConfig,
-        tenant_id: String,
-    ) -> Self {
+    pub fn from_global_config(global_config: &GlobalConfig, tenant_id: String) -> Self {
         Self {
             tenant_id: tenant_id.clone(),
             locker_secrets: global_config.secrets.clone(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -43,7 +43,6 @@ pub struct TenantConfig {
     pub locker_secrets: Secrets,
     pub tenant_secrets: TenantSecrets,
     pub key_manager: KeyManagerConfig,
-    pub schema: String,
 }
 
 impl TenantConfig {
@@ -55,7 +54,6 @@ impl TenantConfig {
     pub fn from_global_config(
         global_config: &GlobalConfig,
         tenant_id: String,
-        schema: Option<String>,
     ) -> Self {
         Self {
             tenant_id: tenant_id.clone(),
@@ -67,7 +65,6 @@ impl TenantConfig {
                 .cloned()
                 .unwrap(),
             key_manager: global_config.key_manager.clone(),
-            schema: schema.unwrap_or(tenant_id),
         }
     }
 }
@@ -121,7 +118,7 @@ pub struct TenantSecrets {
     pub public_key: masking::Secret<String>,
 
     /// schema name for the tenant (defaults to tenant_id)
-    pub schema: Option<String>,
+    pub schema: String,
 }
 
 fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -110,14 +110,19 @@ pub async fn add_card(
         .await?;
 
     if is_new_merchant {
-        keymanager::transfer_key_to_key_manager(
+        let key_transfer = keymanager::transfer_key_to_key_manager(
             &tenant_app_state,
             &merchant.merchant_id,
             keymanager::types::DataKeyTransferRequest::create_request(
                 merchant.enc_key.clone().expose(),
             ),
         )
-        .await?;
+        .await;
+
+        if let Err(err) = key_transfer {
+            tracing::warn!("Failed to transfer key to key manager");
+            tracing::error!(?err);
+        }
     }
 
     let merchant_dek = GcmAes256::new(merchant.enc_key.expose());

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -22,7 +22,7 @@ pub struct HealthRespPayload {
 
 /// '/health` API handler`
 pub async fn health() -> Json<HealthRespPayload> {
-    crate::logger::info!("Health was called");
+    crate::logger::debug!("Health was called");
     Json(HealthRespPayload {
         message: "Health is good".into(),
     })

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -108,18 +108,10 @@ pub async fn decrypt(
             key1: Some(inner_key1),
             key2: Some(inner_key2),
         } => {
-            let tenant_secrets = global_app_state
-                .global_config
-                .tenant_secrets
-                .get(&tenant_id)
-                .ok_or(error_stack::report!(error::ApiError::TenantError(
-                    "Error while retrieving tenant config"
-                )))?;
 
             let mut tenant_config = TenantConfig::from_global_config(
                 &global_app_state.global_config,
                 tenant_id.to_owned(),
-                tenant_secrets.schema.clone()
             );
             aes_decrypt_custodian_key(&mut tenant_config, inner_key1, inner_key2).await?;
 

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -108,11 +108,9 @@ pub async fn decrypt(
             key1: Some(inner_key1),
             key2: Some(inner_key2),
         } => {
-
             let mut tenant_config = TenantConfig::from_global_config(
                 &global_app_state.global_config,
                 tenant_id.to_owned(),
-                tenant_secrets.schema.clone(),
             );
             aes_decrypt_custodian_key(&mut tenant_config, inner_key1, inner_key2).await?;
 

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -108,9 +108,18 @@ pub async fn decrypt(
             key1: Some(inner_key1),
             key2: Some(inner_key2),
         } => {
+            let tenant_secrets = global_app_state
+                .global_config
+                .tenant_secrets
+                .get(&tenant_id)
+                .ok_or(error_stack::report!(error::ApiError::TenantError(
+                    "Error while retrieving tenant config"
+                )))?;
+
             let mut tenant_config = TenantConfig::from_global_config(
                 &global_app_state.global_config,
                 tenant_id.to_owned(),
+                tenant_secrets.schema.clone()
             );
             aes_decrypt_custodian_key(&mut tenant_config, inner_key1, inner_key2).await?;
 

--- a/src/routes/key_migration.rs
+++ b/src/routes/key_migration.rs
@@ -90,9 +90,8 @@ pub async fn migrate_key_to_key_manager(
         Some(request_body),
     )
     .await
-    .map_err(|err| {
-        logger::error!("Failed to migrate merchant: {}", entity_id);
-        err
+    .inspect_err(|err| {
+        logger::error!(?err, "Failed to migrate merchant: {}", entity_id);
     })?
     .deserialize_json::<DataKeyCreateResponse, DataKeyTransferError>()
     .await?;
@@ -101,8 +100,7 @@ pub async fn migrate_key_to_key_manager(
         .db
         .insert_entity(entity_id, &response.identifier.get_identifier())
         .await
-        .map_err(|err| {
-            logger::error!("Failed to insert into entity table: {}", entity_id);
-            err
+        .inspect_err(|err| {
+            logger::error!(?err, "Failed to insert into entity table: {}", entity_id);
         })?)
 }

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -31,7 +31,7 @@ impl GlobalAppState {
         let tenants_key_state = {
             let mut tenants_key_state: FxHashMap<String, CustodianKeyState> = FxHashMap::default();
             for (tenant, _) in known_tenants.clone() {
-                tenants_key_state.insert(tenant, CustodianKeyState::default());
+                tenants_key_state.insert(tenant.clone(), CustodianKeyState::default());
             }
             tenants_key_state
         };

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -25,7 +25,11 @@ impl GlobalAppState {
     /// If tenant specific AppState construction fails when `key_custodian` feature is disabled
     ///
     pub async fn new(global_config: GlobalConfig) -> Arc<Self> {
-        let known_tenants = global_config.tenant_secrets.keys().cloned().collect::<Vec<_>>();
+        let known_tenants = global_config
+            .tenant_secrets
+            .keys()
+            .cloned()
+            .collect::<Vec<_>>();
 
         #[cfg(feature = "key_custodian")]
         let tenants_key_state = {


### PR DESCRIPTION
### Description

Add support for providing separate `schema` to support granularity when choosing the underlying database schema with respect to the tenant.