### PR TITLE
feat(router): add support v2 `/add` `/retrieve` `/delete` api handler

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -5,18 +5,18 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 8080
+port = 3030
 
 [limit]
 request_count = 1
 duration = 60
 
 [database]
-username = "sam"
-password = "damn"
+username = "db_user"
+password = "db_pass"
 host = "localhost"
 port = 5432
-dbname = "locker"
+dbname = "locker_copy"
 
 [cache]
 tti = 7200 # i.e. 2 hours

--- a/config/development.toml
+++ b/config/development.toml
@@ -5,7 +5,7 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 3030
+port = 8080
 
 [limit]
 request_count = 1
@@ -16,7 +16,7 @@ username = "db_user"
 password = "db_pass"
 host = "localhost"
 port = 5432
-dbname = "locker_copy"
+dbname = "locker"
 
 [cache]
 tti = 7200 # i.e. 2 hours

--- a/docs/openapi-v2/spec.yml
+++ b/docs/openapi-v2/spec.yml
@@ -1,0 +1,298 @@
+openapi: "3.0.2"
+info:
+  title: Tartarus - OpenAPI 3.0
+  description: |-
+    This the the open API 3.0 specification for the card locker.
+    This is used by the [hyperswitch](https://github.com/juspay/hyperswitch) for storing card information securely.
+  version: "1.0"
+tags:
+  - name: Key Custodian
+    description: API used to initialize the locker after deployment.
+  - name: Data
+    description: CRUD APIs to for working with data to be stored in the locker
+paths:
+  /api/v2/vault/add:
+    post:
+      tags:
+        - Data
+      summary: Add Data in Locker
+      description: Add sensitive data in the locker
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: The request body might be JWE + JWS encrypted when using middleware
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/StoreDataRequest"
+        required: true
+      responses:
+        "200":
+          description: Store Data Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/StoreDataResponse"
+  /api/v2/vault/retrieve:
+    post:
+      tags:
+        - Data
+      summary: Retrieve Data from Locker
+      description: Retrieve sensitive data from the locker
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: The request body might be JWE + JWS encrypted when using middleware
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/RetrieveDataRequest"
+        required: true
+      responses:
+        "200":
+          description: Retrieve Data Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/RetrieveDataResponse"
+  /api/v2/vault/delete:
+    post:
+      tags:
+        - Data
+      summary: Delete Data from Locker
+      description: Delete sensitive data from the locker
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: The request body might be JWE + JWS encrypted when using middleware
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/DeleteDataRequest"
+        required: true
+      responses:
+        "200":
+          description: Delete Data Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/DeleteDataResponse"
+  /custodian/key1:
+    post:
+      tags:
+        - Key Custodian
+      summary: Provide Key 1
+      description: Provide the first key to unlock the locker
+      operationId: setKey1
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: Provide key 1 to unlock the locker
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Key"
+        required: true
+      responses:
+        "200":
+          description: Key 1 provided
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Key1Set"
+  /custodian/key2:
+    post:
+      tags:
+        - Key Custodian
+      summary: Provide Key 2
+      description: Provide the first key to unlock the locker
+      operationId: setKey2
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: Provide key 2 to unlock the locker
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/Key"
+        required: true
+      responses:
+        "200":
+          description: Key 2 provided
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Key2Set"
+  /custodian/decrypt:
+    post:
+      tags:
+        - Key Custodian
+      summary: Unlock the locker
+      description: Unlock the locker with the key1 and key2 provided
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Successfully Unlocked
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Decrypt200"
+  /health:
+    get:
+      summary: Get Health
+      description: To check whether the application is up
+      responses:
+        "200":
+          description: Health is good
+          content:
+            text/plain:
+              schema:
+                $ref: "#/components/schemas/Health"
+  /api/v2/fingerprint:
+    post:
+      tags:
+        - Data
+      summary: Get or insert the card fingerprint
+      description: Get or insert the card fingerprint
+      parameters:
+        - in: header
+          name: x-tenant-id
+          schema:
+            type: string
+      requestBody:
+        description: Provide card number and hash key
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/FingerprintReq"
+        required: true
+      responses:
+        "200":
+          description: Fingerprint Response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/FingerprintRes"
+components:
+  schemas:
+    Key:
+      type: object
+      properties:
+        key:
+          type: string
+          example: 801bb63c1bd51820acbc8ac20c674675
+      required:
+        - key
+    DeleteDataRequest:
+      type: object
+      properties:
+        entity_id:
+          type: string
+        vault_id:
+          type: string
+    DeleteDataResponse:
+      type: object
+      properties:
+        entity_id:
+          type: string
+        vault_id:
+          type: string
+    RetrieveDataRequest:
+      type: object
+      properties:
+        entity_id:
+          type: string
+        vault_id:
+          type: string
+    RetrieveDataResponse:
+      type: object
+      properties:
+        data:
+          $ref: "#/components/schemas/Secret"
+    StoreDataRequest:
+      type: object
+      properties:
+        entity_id:
+          type: string
+        vault_id:
+          type: string
+        data:
+          $ref: "#/components/schemas/Secret"
+        ttl:
+          $ref: "#/components/schemas/Ttl"
+    StoreDataResponse:
+      type: object
+      properties:
+        entity_id:
+          type: string
+        vault_id:
+          type: string
+    Secret:
+      type: object
+      properties:
+        data:
+          type: string
+    Ttl:
+      type: integer
+      description: Time-to-live in seconds
+    Key1Set:
+      type: string
+      description: Response after setting key1
+      example: Received Key1
+    Key2Set:
+      type: string
+      description: Response after setting key2
+      example: Received Key2
+    Decrypt200:
+      type: string
+      description: Response if the locker key custodian decryption was successful
+      example: Decryption successful
+    Health:
+      type: string
+      description: Response when the health is good
+      example: health is good
+    FingerprintReq:
+      type: object
+      properties:
+        card:
+          $ref: "#/components/schemas/FingerprintCardData"
+        hash_key:
+          type: string
+          example: Hash1
+    FingerprintRes:
+      type: object
+      description: Response received if the fingerprint insertion or retrieval was successful
+      properties:
+        status:
+          type: string
+          enum: [Ok]
+        payload:
+          type: object
+          properties:
+            fingerprint:
+              type: string
+    FingerprintCardData:
+      type: object
+      properties:
+        card_number:
+          type: string
+          example: 4242424242424242

--- a/src/app.rs
+++ b/src/app.rs
@@ -118,7 +118,11 @@ where
         axum::Router::new()
             .route("/delete", post(routes_v2::data::delete_data))
             .route("/add", post(routes_v2::data::add_data))
-            .route("/retrieve", post(routes_v2::data::retrieve_data)),
+            .route("/retrieve", post(routes_v2::data::retrieve_data))
+            .route(
+                "/fingerprint",
+                post(routes::data::get_or_insert_fingerprint),
+            ),
     );
 
     let router = router.layer(

--- a/src/custom_extractors.rs
+++ b/src/custom_extractors.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use axum::{async_trait, extract::FromRequestParts, http::request::Parts};
 
-use crate::{app::TenantAppState, error::ApiError, tenant::GlobalAppState};
+use crate::{app::TenantAppState, error::ApiError, storage::consts, tenant::GlobalAppState};
 
 #[derive(Clone)]
 pub struct TenantStateResolver(pub Arc<TenantAppState>);
@@ -17,7 +17,7 @@ impl FromRequestParts<Arc<GlobalAppState>> for TenantStateResolver {
     ) -> Result<Self, Self::Rejection> {
         let tenant_id = parts
             .headers
-            .get("x-tenant-id")
+            .get(consts::X_TENANT_ID)
             .and_then(|h| h.to_str().ok())
             .ok_or(ApiError::TenantError("x-tenant-id not found in headers"))?;
 
@@ -41,7 +41,7 @@ impl FromRequestParts<Arc<GlobalAppState>> for TenantId {
     ) -> Result<Self, Self::Rejection> {
         let tenant_id = parts
             .headers
-            .get("x-tenant-id")
+            .get(consts::X_TENANT_ID)
             .and_then(|h| h.to_str().ok())
             .map(ToString::to_string)
             .ok_or(ApiError::TenantError("x-tenant-id not found in header"))?;

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -117,14 +117,17 @@ pub async fn add_card(
                 .await?;
 
             let (duplication_check, output) = match stored_data {
-                Some(mut locker) => {
-                    crypto_operation::decrypt_data(&tenant_app_state, crypto_manager, &mut locker)
-                        .await?;
+                Some(locker) => {
+                    let decrypted_locker_data =
+                        crypto_operation::decrypt_data(&tenant_app_state, crypto_manager, locker)
+                            .await?;
 
-                    let duplication_check =
-                        transformers::validate_card_metadata(&locker, &request.data)?;
+                    let duplication_check = transformers::validate_card_metadata(
+                        &decrypted_locker_data,
+                        &request.data,
+                    )?;
 
-                    (Some(duplication_check), locker)
+                    (Some(duplication_check), decrypted_locker_data)
                 }
                 None => {
                     let encrypted_locker_data = crypto_operation::encrypt_data_and_insert_into_db(
@@ -194,7 +197,7 @@ pub async fn retrieve_card(
         .find_by_entity_id(&tenant_app_state, request.merchant_id.clone())
         .await?;
 
-    let mut locker = tenant_app_state
+    let locker = tenant_app_state
         .db
         .find_by_locker_id_merchant_id_customer_id(
             request.card_reference.clone().into(),
@@ -203,9 +206,10 @@ pub async fn retrieve_card(
         )
         .await?;
 
-    crypto_operation::decrypt_data(&tenant_app_state, crypto_manager, &mut locker).await?;
+    let decrypted_locker_data =
+        crypto_operation::decrypt_data(&tenant_app_state, crypto_manager, locker).await?;
 
-    locker
+    decrypted_locker_data
         .ttl
         .map(|ttl| -> Result<(), error::ApiError> {
             if utils::date_time::now() > ttl {
@@ -227,7 +231,7 @@ pub async fn retrieve_card(
         })
         .transpose()?;
 
-    Ok(Json(locker.try_into()?))
+    Ok(Json(decrypted_locker_data.try_into()?))
 }
 
 /// `/cards/fingerprint` handling the creation and retrieval of card fingerprint

--- a/src/routes/data/crypto_operation.rs
+++ b/src/routes/data/crypto_operation.rs
@@ -41,8 +41,8 @@ pub async fn encrypt_data_and_insert_into_db<'a>(
 pub async fn decrypt_data<T>(
     tenant_app_state: &TenantAppState,
     crypto_operator: Box<dyn CryptoOperationsManager>,
-    data: &mut T,
-) -> Result<(), ContainerError<error::ApiError>>
+    mut data: T,
+) -> Result<T, ContainerError<error::ApiError>>
 where
     T: types::SecretDataManager,
 {
@@ -51,9 +51,11 @@ where
             .decrypt_data(tenant_app_state, encrypted_data)
             .await?;
 
-        data.set_decrypted_data(decrypted_data);
+        data = data.set_decrypted_data(decrypted_data);
+        Ok(data)
+    } else {
+        Err(error::ApiError::NotFoundError.into())
     }
-    Ok(())
 }
 
 pub async fn encrypt_data_and_insert_into_db_v2(

--- a/src/routes/data/crypto_operation.rs
+++ b/src/routes/data/crypto_operation.rs
@@ -52,10 +52,8 @@ where
             .await?;
 
         data = data.set_decrypted_data(decrypted_data);
-        Ok(data)
-    } else {
-        Err(error::ApiError::NotFoundError.into())
     }
+    Ok(data)
 }
 
 pub async fn encrypt_data_and_insert_into_db_v2(

--- a/src/routes/data/crypto_operation.rs
+++ b/src/routes/data/crypto_operation.rs
@@ -1,10 +1,13 @@
+use masking::ExposeInterface;
+
 use crate::{
     app::TenantAppState,
     crypto::keymanager::CryptoOperationsManager,
     error::{self, ContainerError, ResultContainerExt},
     routes::data::types,
     storage::{
-        types::{Encryptable, Locker, LockerNew},
+        storage_v2::{types::VaultNew, VaultInterface},
+        types::{Locker, LockerNew},
         LockerInterface,
     },
 };
@@ -35,18 +38,42 @@ pub async fn encrypt_data_and_insert_into_db<'a>(
     Ok(locker)
 }
 
-pub async fn decrypt_data(
+pub async fn decrypt_data<T>(
     tenant_app_state: &TenantAppState,
     crypto_operator: Box<dyn CryptoOperationsManager>,
-    mut locker: Locker,
-) -> Result<Locker, ContainerError<error::ApiError>> {
-    if let Some(encrypted_data) = locker.data.get_encrypted_inner_value() {
+    data: &mut T,
+) -> Result<(), ContainerError<error::ApiError>>
+where
+    T: types::SecretDataManager,
+{
+    if let Some(encrypted_data) = data.get_encrypted_inner_value() {
         let decrypted_data = crypto_operator
             .decrypt_data(tenant_app_state, encrypted_data)
             .await?;
 
-        locker.data = Encryptable::from_decrypted_data(decrypted_data)
+        data.set_decrypted_data(decrypted_data);
     }
+    Ok(())
+}
 
-    Ok(locker)
+pub async fn encrypt_data_and_insert_into_db_v2(
+    tenant_app_state: &TenantAppState,
+    crypto_operator: Box<dyn CryptoOperationsManager>,
+    request: crate::routes::routes_v2::data::types::StoreDataRequest,
+) -> Result<crate::storage::storage_v2::types::Vault, ContainerError<error::ApiError>> {
+    let data_to_be_encrypted = serde_json::to_vec(&request.data.clone().expose())
+        .change_error(error::ApiError::EncodingError)?;
+
+    let encrypted_data = crypto_operator
+        .encrypt_data(tenant_app_state, data_to_be_encrypted.into())
+        .await?;
+
+    let vault_new = VaultNew::new(request, encrypted_data.into());
+
+    let vault = tenant_app_state
+        .db
+        .insert_or_get_from_vault(vault_new)
+        .await?;
+
+    Ok(vault)
 }

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -31,7 +31,7 @@ impl From<storage::storage_v2::types::Vault>
     fn from(value: storage::storage_v2::types::Vault) -> Self {
         Self {
             entity_id: value.entity_id,
-            vault_id: value.vault_id.expose(),
+            vault_id: value.vault_id,
         }
     }
 }

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -25,6 +25,17 @@ impl From<(Option<DataDuplicationCheck>, storage::types::Locker)>
     }
 }
 
+impl From<storage::storage_v2::types::Vault>
+    for crate::routes::routes_v2::data::types::StoreDataResponse
+{
+    fn from(value: storage::storage_v2::types::Vault) -> Self {
+        Self {
+            entity_id: value.entity_id,
+            vault_id: value.vault_id.expose(),
+        }
+    }
+}
+
 impl TryFrom<storage::types::Locker> for super::types::RetrieveCardResponse {
     type Error = ContainerError<error::ApiError>;
     fn try_from(value: storage::types::Locker) -> Result<Self, Self::Error> {

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -1,15 +1,13 @@
-// #[derive(serde::Serialize, serde::Deserialize)]
-// #[serde(rename_all = "camelCase")]
-// pub struct Dedup {
-//     hash1: Option<String>,
-//     hash2: Option<String>,
-//     hash1_reference: Option<String>,
-//     hash2_reference: Option<String>,
-// }
+use masking::{Secret, StrongSecret};
 
-use masking::Secret;
-
-use crate::{error, storage, utils};
+use crate::{
+    error,
+    storage::{
+        self,
+        types::{Encryptable, Locker},
+    },
+    utils,
+};
 
 #[derive(serde::Serialize, serde::Deserialize, Debug, PartialEq, Eq, Clone)]
 pub struct Card {
@@ -178,5 +176,20 @@ impl Validation for StoreCardRequest {
             Data::EncData { .. } => Ok(()),
             Data::Card { card } => card.card_number.validate(),
         }
+    }
+}
+
+pub trait SecretDataManager {
+    fn get_encrypted_inner_value(&self) -> Option<Secret<Vec<u8>>>;
+    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>);
+}
+
+impl SecretDataManager for Locker {
+    fn get_encrypted_inner_value(&self) -> Option<Secret<Vec<u8>>> {
+        self.data.get_encrypted_inner_value()
+    }
+
+    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>) {
+        self.data = Encryptable::from_decrypted_data(decrypted_data);
     }
 }

--- a/src/routes/data/types.rs
+++ b/src/routes/data/types.rs
@@ -181,7 +181,7 @@ impl Validation for StoreCardRequest {
 
 pub trait SecretDataManager {
     fn get_encrypted_inner_value(&self) -> Option<Secret<Vec<u8>>>;
-    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>);
+    fn set_decrypted_data(self, decrypted_data: StrongSecret<Vec<u8>>) -> Self;
 }
 
 impl SecretDataManager for Locker {
@@ -189,7 +189,8 @@ impl SecretDataManager for Locker {
         self.data.get_encrypted_inner_value()
     }
 
-    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>) {
+    fn set_decrypted_data(mut self, decrypted_data: StrongSecret<Vec<u8>>) -> Self {
         self.data = Encryptable::from_decrypted_data(decrypted_data);
+        self
     }
 }

--- a/src/routes/routes_v2/data.rs
+++ b/src/routes/routes_v2/data.rs
@@ -1,31 +1,94 @@
 use axum::Json;
+use error_stack::ResultExt;
+use masking::PeekInterface;
 pub mod types;
 
 use crate::{
+    crypto::keymanager::{self, KeyProvider},
     custom_extractors::TenantStateResolver,
-    error::{self, ContainerError},
+    error::{self, ContainerError, ResultContainerExt},
+    routes::data::crypto_operation,
+    storage::storage_v2::VaultInterface,
+    utils,
 };
 
 pub async fn delete_data(
-    TenantStateResolver(_tenant_app_state): TenantStateResolver,
-    Json(_request): Json<types::DeleteDataRequest>,
+    TenantStateResolver(tenant_app_state): TenantStateResolver,
+    Json(request): Json<types::DeleteDataRequest>,
 ) -> Result<Json<types::DeleteDataResponse>, ContainerError<error::ApiError>> {
-    // need handle this once the key manger service is ready
-    todo!()
+    let _entity = keymanager::get_dek_manager()
+        .find_by_entity_id(&tenant_app_state, request.entity_id.clone())
+        .await?;
+
+    let _delete_status = tenant_app_state
+        .db
+        .delete_from_vault(request.vault_id.clone().into(), &request.entity_id)
+        .await?;
+    Ok(Json(types::DeleteDataResponse {
+        entity_id: request.entity_id,
+        vault_id: request.vault_id,
+    }))
 }
 
 pub async fn retrieve_data(
-    TenantStateResolver(_tenant_app_state): TenantStateResolver,
-    Json(_request): Json<types::RetrieveDataRequest>,
+    TenantStateResolver(tenant_app_state): TenantStateResolver,
+    Json(request): Json<types::RetrieveDataRequest>,
 ) -> Result<Json<types::RetrieveDataResponse>, ContainerError<error::ApiError>> {
-    // need handle this once the key manger service is ready
-    todo!()
+    let crypto_manager = keymanager::get_dek_manager()
+        .find_by_entity_id(&tenant_app_state, request.entity_id.clone())
+        .await?;
+
+    let mut vault = tenant_app_state
+        .db
+        .find_by_vault_id_entity_id(request.vault_id.clone().into(), &request.entity_id)
+        .await?;
+
+    crypto_operation::decrypt_data(&tenant_app_state, crypto_manager, &mut vault).await?;
+
+    vault
+        .expires_at
+        .map(|ttl| -> Result<(), error::ApiError> {
+            if utils::date_time::now() > ttl {
+                tokio::spawn(async move {
+                    tenant_app_state
+                        .db
+                        .delete_from_vault(request.vault_id.into(), &request.entity_id)
+                        .await
+                });
+
+                Err(error::ApiError::NotFoundError)
+            } else {
+                Ok(())
+            }
+        })
+        .transpose()?;
+    let decrypted_data = vault
+        .data
+        .get_decrypted_inner_value()
+        .ok_or(error::ApiError::UnknownError)
+        .attach_printable("Failed to decrypt the stored data")?;
+    let decrypted_data_value = serde_json::from_slice(decrypted_data.peek().as_ref())
+        .change_error(error::ApiError::DecodingError)?;
+
+    Ok(Json(types::RetrieveDataResponse {
+        data: decrypted_data_value,
+    }))
 }
 
 pub async fn add_data(
-    TenantStateResolver(_tenant_app_state): TenantStateResolver,
-    Json(_request): Json<types::StoreDataRequest>,
+    TenantStateResolver(tenant_app_state): TenantStateResolver,
+    Json(request): Json<types::StoreDataRequest>,
 ) -> Result<Json<types::StoreDataResponse>, ContainerError<error::ApiError>> {
-    // need handle this once the key manger service is ready
-    todo!()
+    let crypto_manager = keymanager::get_dek_manager()
+        .find_or_create_entity(&tenant_app_state, request.entity_id.clone())
+        .await?;
+
+    let insert_data = crypto_operation::encrypt_data_and_insert_into_db_v2(
+        &tenant_app_state,
+        crypto_manager,
+        request,
+    )
+    .await?;
+
+    Ok(Json(types::StoreDataResponse::from(insert_data)))
 }

--- a/src/routes/routes_v2/data/types.rs
+++ b/src/routes/routes_v2/data/types.rs
@@ -39,7 +39,7 @@ pub struct StoreDataRequest {
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct StoreDataResponse {
     pub entity_id: String,
-    pub vault_id: String,
+    pub vault_id: Secret<String>,
 }
 
 impl SecretDataManager for Vault {
@@ -47,7 +47,8 @@ impl SecretDataManager for Vault {
         self.data.get_encrypted_inner_value()
     }
 
-    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>) {
+    fn set_decrypted_data(mut self, decrypted_data: StrongSecret<Vec<u8>>) -> Self {
         self.data = Encryptable::from_decrypted_data(decrypted_data);
+        self
     }
 }

--- a/src/routes/routes_v2/data/types.rs
+++ b/src/routes/routes_v2/data/types.rs
@@ -1,6 +1,9 @@
-use masking::Secret;
+use masking::{Secret, StrongSecret};
 
-use crate::routes::data::types::Ttl;
+use crate::{
+    routes::data::types::{SecretDataManager, Ttl},
+    storage::{storage_v2::types::Vault, types::Encryptable},
+};
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct DeleteDataRequest {
@@ -22,7 +25,7 @@ pub struct RetrieveDataRequest {
 
 #[derive(serde::Serialize, serde::Deserialize)]
 pub struct RetrieveDataResponse {
-    pub payload: Secret<serde_json::Value>,
+    pub data: Secret<serde_json::Value>,
 }
 
 #[derive(serde::Serialize, serde::Deserialize, Debug)]
@@ -37,4 +40,14 @@ pub struct StoreDataRequest {
 pub struct StoreDataResponse {
     pub entity_id: String,
     pub vault_id: String,
+}
+
+impl SecretDataManager for Vault {
+    fn get_encrypted_inner_value(&self) -> Option<Secret<Vec<u8>>> {
+        self.data.get_encrypted_inner_value()
+    }
+
+    fn set_decrypted_data(&mut self, decrypted_data: StrongSecret<Vec<u8>>) {
+        self.data = Encryptable::from_decrypted_data(decrypted_data);
+    }
 }

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -8,3 +8,6 @@ pub(crate) const ALPHABETS: [char; 62] = [
 
 /// Number of characters in a generated ID
 pub const ID_LENGTH: usize = 20;
+
+/// Header key for tenant ID
+pub const X_TENANT_ID: &str = "x-tenant-id";

--- a/src/storage/storage_v2.rs
+++ b/src/storage/storage_v2.rs
@@ -19,14 +19,12 @@ pub(crate) trait VaultInterface {
         &self,
         vault_id: Secret<String>,
         entity_id: &str,
-        key: &Self::Algorithm,
     ) -> Result<types::Vault, ContainerError<Self::Error>>;
 
     /// Insert data into vault table
     async fn insert_or_get_from_vault(
         &self,
         new: types::VaultNew,
-        key: &Self::Algorithm,
     ) -> Result<types::Vault, ContainerError<Self::Error>>;
 
     /// Delete data from the vault

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -299,15 +299,6 @@ pub(super) trait StorageDecryption: Sized {
     ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output>;
 }
 
-pub(super) trait StorageEncryption: Sized {
-    type Output;
-    type Algorithm: Encryption<Vec<u8>, Vec<u8>>;
-    fn encrypt(
-        self,
-        algo: &Self::Algorithm,
-    ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output>;
-}
-
 impl StorageDecryption for MerchantInner {
     type Output = Merchant;
 
@@ -321,22 +312,6 @@ impl StorageDecryption for MerchantInner {
             merchant_id: self.merchant_id,
             enc_key: algo.decrypt(self.enc_key.into_inner().expose())?.into(),
             created_at: self.created_at,
-        })
-    }
-}
-
-impl<'a> StorageEncryption for MerchantNew<'a> {
-    type Output = MerchantNewInner<'a>;
-
-    type Algorithm = GcmAes256;
-
-    fn encrypt(
-        self,
-        algo: &Self::Algorithm,
-    ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output> {
-        Ok(Self::Output {
-            merchant_id: self.merchant_id,
-            enc_key: algo.encrypt(self.enc_key.expose())?.into(),
         })
     }
 }

--- a/src/utils.rs
+++ b/src/utils.rs
@@ -1,5 +1,7 @@
 use axum::{body::Body, extract::Request};
 
+use crate::storage::consts;
+
 /// Date-time utilities.
 pub mod date_time {
     use time::{OffsetDateTime, PrimitiveDateTime};
@@ -21,7 +23,7 @@ pub fn record_tenant_id_from_header(request: &Request<Body>) -> tracing::Span {
 
     match request
         .headers()
-        .get("x-tenant-id")
+        .get(consts::X_TENANT_ID)
         .and_then(|value| value.to_str().ok())
     {
         Some(value) => inner_trace!(value),


### PR DESCRIPTION
This pr adds the api handler to `/add` `/retrieve` and `/delete`  `v2` endpoints.
Also adds `/fingerprint` under `v2` that uses the same function as v1 just for the unification purpose .

test case
-> Add data
```
curl --location 'http://localhost:3030/api/v2/vault/add' \
--header 'x-tenant-id: hyperswitch' \
--header 'Content-Type: application/json' \
--data '{
    "entity_id": "hyperswitch",
    "vault_id": "123456789",
    "data": {
        "card_number": "4111111111111111",
        "name_on_card": "hyperswitch vaut"
    }
}'
```
```
{
    "entity_id": "hyperswitch",
    "vault_id": "123456789"
}
```
<img width="643" alt="image" src="https://github.com/user-attachments/assets/d6070822-f29c-4ac6-a7ba-0a84bbd6cc1a">
<img width="1422" alt="image" src="https://github.com/user-attachments/assets/e54ff401-8e23-465c-b35b-6cc007f273f5">

-> retrieve data
```
curl --location 'http://localhost:3030/api/v2/vault/retrieve' \
--header 'x-tenant-id: hyperswitch' \
--header 'Content-Type: application/json' \
--data '{
   "entity_id": "hyperswitch",
    "vault_id": "123456789"
}'
```
```
{
    "data": {
        "card_number": "4111111111111111",
        "name_on_card": "hyperswitch vaut"
    }
}
```

-> delete data
```
curl --location 'http://localhost:3030/api/v2/vault/delete' \
--header 'x-tenant-id: hyperswitch' \
--header 'Content-Type: application/json' \
--data '{
    "entity_id": "hyperswitch",
    "vault_id": "123456789"
}'
```
```
{
    "entity_id": "hyperswitch",
    "vault_id": "123456789"
}
```
<img width="747" alt="image" src="https://github.com/user-attachments/assets/ad2fa49c-7e7d-45b7-b72a-62e9b815a17f">
