### PR TITLE
feat(keymanager): add support for sending master key to key manager

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ rust-version = "1.78"
 
 [features]
 default = ["caching"]
-release = ["kms-aws", "middleware", "key_custodian", "limit", "kms-hashicorp-vault", "caching"]
+release = ["kms-aws", "middleware", "key_custodian", "limit", "kms-hashicorp-vault", "caching", "keymanager_mtls"]
 kms-aws = ["dep:aws-config", "dep:aws-sdk-kms"]
 kms-hashicorp-vault = ["dep:vaultrs"]
 limit = []

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -145,7 +145,7 @@ where
         let (left_half, right_half) = broken_master_key.split_at(broken_master_key.len() / 2);
         let hex_left = hex::encode(left_half);
         let hex_right = hex::encode(right_half);
-        BASE64_ENGINE.encode(format!("{}{}", hex_left, hex_right))
+        BASE64_ENGINE.encode(format!("{}:{}", hex_left, hex_right))
     };
     let headers = [
         (headers::CONTENT_TYPE.into(), "application/json".into()),

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -1,4 +1,5 @@
 pub mod types;
+use base64::Engine;
 use masking::{ExposeInterface, Secret};
 use serde::Deserialize;
 
@@ -17,6 +18,8 @@ use crate::{
     routes::health,
     storage::{consts::headers, types::Entity, EntityInterface},
 };
+
+use super::consts::BASE64_ENGINE;
 
 #[derive(Debug, Deserialize, Clone)]
 pub struct KeyManagerConfig {
@@ -137,9 +140,22 @@ where
     T: serde::Serialize + Send + Sync + 'static,
     ContainerError<E>: From<ContainerError<ApiClientError>> + Send + Sync,
 {
-    let headers = [(headers::CONTENT_TYPE.into(), "application/json".into())]
-        .into_iter()
-        .collect::<std::collections::HashSet<_>>();
+    let broken_master_key = {
+        let broken_master_key = &state.config.tenant_secrets.master_key;
+        let (left_half, right_half) = broken_master_key.split_at(broken_master_key.len() / 2);
+        let hex_left = hex::encode(left_half);
+        let hex_right = hex::encode(right_half);
+        BASE64_ENGINE.encode(format!("{}{}", hex_left, hex_right))
+    };
+    let headers = [
+        (headers::CONTENT_TYPE.into(), "application/json".into()),
+        (
+            "authorization".into(),
+            format!("Basic {}", broken_master_key).into(),
+        ),
+    ]
+    .into_iter()
+    .collect::<std::collections::HashSet<_>>();
     let response = state
         .api_client
         .send_request::<_>(url, headers, method, request_body)

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -150,7 +150,7 @@ where
     let headers = [
         (headers::CONTENT_TYPE.into(), "application/json".into()),
         (
-            "authorization".into(),
+            headers::AUTHORIZATION.into(),
             format!("Basic {}", broken_master_key).into(),
         ),
     ]

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -12,4 +12,5 @@ pub const ID_LENGTH: usize = 20;
 /// Header Constants
 pub mod headers {
     pub const CONTENT_TYPE: &str = "Content-Type";
+    pub const AUTHORIZATION: &str = "Authorization";
 }


### PR DESCRIPTION
## Description
This pull request includes several changes to the `src/crypto/keymanager.rs` file, primarily focusing on the introduction of base64 encoding for authorization headers and the use of constants for the base64 engine. Below is a summary of the most important changes:

### Introduction of Base64 Encoding for Authorization Headers

* Added the `base64::Engine` import to enable base64 encoding functionality.
* Introduced the `BASE64_ENGINE` constant from `consts` to standardize the base64 encoding process.
* Modified the header generation to include a base64 encoded authorization header by splitting the master key, encoding its halves in hex, and then combining and encoding them in base64.