### PR TITLE
fix(mtls): fix provider import for mtls

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,10 +16,9 @@ limit = []
 middleware = []
 key_custodian = []
 caching = ["dep:moka"]
-keymanager_mtls = ["reqwest/rustls-tls"]
 console = ["tokio/tracing", "dep:console-subscriber"]
 external_key_manager = []
-external_key_manager_mtls = ["external_key_manager"]
+external_key_manager_mtls = ["external_key_manager", "reqwest/rustls-tls"]
 
 [dependencies]
 async-trait = "0.1.81"


### PR DESCRIPTION
This pull request includes a change to the `Cargo.toml` file to update the dependencies for the `external_key_manager_mtls` feature.

Dependency updates:

* [`Cargo.toml`](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542L19-R21): Added `reqwest/rustls-tls` to the `external_key_manager_mtls` feature to ensure it includes the necessary dependencies for mutual TLS support.