### PR TITLE
refactor: record `tenant_id` and `request_id` from header in the trace span

### DIFF
--- a/config/development.toml
+++ b/config/development.toml
@@ -5,7 +5,7 @@ log_format = "default"
 
 [server]
 host = "127.0.0.1"
-port = 8080
+port = 3001
 
 [limit]
 request_count = 1
@@ -54,7 +54,7 @@ Sau7H1Bhzy5G7rwt05LNpU6nFcAGVaZtzl4/+FYfYIulubYjuSEh72yuBHHyvi1/
 """
 
 [tenant_secrets]
-hyperswitch = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
+public = { master_key = "feffe9928665731c6d6a8f9467308308feffe9928665731c6d6a8f9467308308", public_key = """
 -----BEGIN PUBLIC KEY-----
 MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA5Z/K0JWds8iHhWCa+rj0
 rhOQX1nVs/ArQ1D0vh3UlSPR2vZUTrkdP7i3amv4d2XDC+3+5/YWExTkpxqnfl1T

--- a/src/app.rs
+++ b/src/app.rs
@@ -138,7 +138,7 @@ where
 
     let router = router.layer(
         tower_trace::TraceLayer::new_for_http()
-            .make_span_with(|request: &Request<_>| utils::record_tenant_id_from_header(request))
+            .make_span_with(|request: &Request<_>| utils::record_fields_from_header(request))
             .on_request(tower_trace::DefaultOnRequest::new().level(tracing::Level::INFO))
             .on_response(
                 tower_trace::DefaultOnResponse::new()

--- a/src/error.rs
+++ b/src/error.rs
@@ -86,7 +86,7 @@ pub enum ApiError {
     #[error("Failed while decoding data")]
     DecodingError,
 
-    #[error("Failed while inserting data into \"{0}\"")]
+    #[error("Failed while inserting data into {0}")]
     DatabaseInsertFailed(&'static str),
 
     #[error("failed while deleting data from {0}")]

--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -126,10 +126,9 @@ where
             if !IMPLICIT_KEYS.contains(key.as_str()) {
                 true
             } else {
-                tracing::warn!(
-                    ?key,
-                    ?value,
-                    "Attempting to log a reserved entry. It won't be added to the logs"
+                eprintln!(
+                    "Attempting to log a reserved entry. It won't be added to the logs. key: {:?}, value: {:?}",
+                    key, value
                 );
                 false
             }

--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -193,9 +193,7 @@ where
                         map_serializer.serialize_entry(key, value)?;
                     } else {
                         tracing::warn!(
-                            ?key,
-                            ?value,
-                            "Attempting to log a reserved entry. It won't be added to the logs"
+                            "Attempting to log a reserved entry. It won't be added to the logs. key: {key:?}, value: {value:?}"
                         );
                     }
                 }

--- a/src/logger/storage.rs
+++ b/src/logger/storage.rs
@@ -23,10 +23,18 @@ pub struct Storage<'a> {
     pub values: HashMap<&'a str, serde_json::Value>,
 }
 
-impl Storage<'_> {
+impl<'a> Storage<'a> {
     /// Default constructor.
     pub fn new() -> Self {
         Self::default()
+    }
+
+    pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
+        if super::formatter::IMPLICIT_KEYS.contains(key) {
+            tracing::warn!(value =? value, "{} is a reserved entry. Skipping it.", key);
+        } else {
+            self.values.insert(key, value);
+        }
     }
 }
 
@@ -43,32 +51,27 @@ impl Default for Storage<'_> {
 impl Visit for Storage<'_> {
     /// A i64.
     fn record_i64(&mut self, field: &Field, value: i64) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
+        self.record_value(field.name(), serde_json::Value::from(value));
     }
 
     /// A u64.
     fn record_u64(&mut self, field: &Field, value: u64) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
+        self.record_value(field.name(), serde_json::Value::from(value));
     }
 
     /// A 64-bit floating point.
     fn record_f64(&mut self, field: &Field, value: f64) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
+        self.record_value(field.name(), serde_json::Value::from(value));
     }
 
     /// A boolean.
     fn record_bool(&mut self, field: &Field, value: bool) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
+        self.record_value(field.name(), serde_json::Value::from(value));
     }
 
     /// A string.
     fn record_str(&mut self, field: &Field, value: &str) {
-        self.values
-            .insert(field.name(), serde_json::Value::from(value));
+        self.record_value(field.name(), serde_json::Value::from(value));
     }
 
     /// Otherwise.
@@ -77,12 +80,10 @@ impl Visit for Storage<'_> {
             // Skip fields which are already handled
             name if name.starts_with("log.") => (),
             name if name.starts_with("r#") => {
-                self.values
-                    .insert(&name[2..], serde_json::Value::from(format!("{value:?}")));
+                self.record_value(&name[2..], serde_json::Value::from(format!("{value:?}")));
             }
             name => {
-                self.values
-                    .insert(name, serde_json::Value::from(format!("{value:?}")));
+                self.record_value(name, serde_json::Value::from(format!("{value:?}")));
             }
         };
     }
@@ -148,7 +149,7 @@ impl<S: Subscriber + for<'a> tracing_subscriber::registry::LookupSpan<'a>> Layer
             .expect("No visitor in extensions");
 
         if let Ok(elapsed) = serde_json::to_value(elapsed_milliseconds) {
-            visitor.values.insert("elapsed_milliseconds", elapsed);
+            visitor.record_value("elapsed_milliseconds", elapsed);
         }
     }
 }

--- a/src/logger/storage.rs
+++ b/src/logger/storage.rs
@@ -31,7 +31,7 @@ impl<'a> Storage<'a> {
 
     pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
         if super::formatter::IMPLICIT_KEYS.contains(key) {
-            tracing::warn!(value =? value, "{} is a reserved entry. Skipping it.", key);
+            tracing::warn!("{key} is a reserved entry. Skipping it. value: {value}");
         } else {
             self.values.insert(key, value);
         }

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -11,6 +11,8 @@ pub const ID_LENGTH: usize = 20;
 
 /// Header key for tenant ID
 pub const X_TENANT_ID: &str = "x-tenant-id";
+/// Header key for request ID
+pub const X_REQUEST_ID: &str = "x-request-id";
 /// Header Constants
 pub mod headers {
     pub const CONTENT_TYPE: &str = "Content-Type";

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -158,7 +158,7 @@ impl LockerInterface for Storage {
             Ok(locker) => Ok(locker),
         };
 
-        output.map_err(From::from).map(|inner| inner.into())
+        output.map_err(From::from).map(From::from)
     }
 
     async fn find_by_hash_id_merchant_id_customer_id(


### PR DESCRIPTION
1. `tenant-id` and `request-id` in console logging - 

![image](https://github.com/user-attachments/assets/001cafe7-7213-44d9-92de-d0de15bb2a21)

2. `tenant-id` and `request-id` in json logging - 

![image](https://github.com/user-attachments/assets/e7f635c9-5a41-49e1-9d71-35b8e0ece023)

3. removed `map_err` in some db methods and used `change_error`, hence getting whole error stack

![image](https://github.com/user-attachments/assets/defa2425-0985-4065-833c-233c79bcf422)
