### PR TITLE
chore: add x-tenant-id in encryption service call

### DIFF
--- a/src/crypto/keymanager/external_keymanager/utils.rs
+++ b/src/crypto/keymanager/external_keymanager/utils.rs
@@ -2,8 +2,9 @@ use std::collections::HashSet;
 
 use base64::Engine;
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
-use masking::Maskable;
+use masking::{Mask, Maskable};
 
+use crate::storage::consts::X_TENANT_ID;
 use crate::{app::TenantAppState, crypto::consts::BASE64_ENGINE};
 
 pub fn get_key_manager_header(
@@ -20,7 +21,11 @@ pub fn get_key_manager_header(
         (CONTENT_TYPE.to_string(), "application/json".into()),
         (
             AUTHORIZATION.to_string(),
-            format!("Basic {}", broken_master_key).into(),
+            format!("Basic {}", broken_master_key).into_masked(),
+        ),
+        (
+            X_TENANT_ID.to_string(),
+            tenant_app_state.config.tenant_id.clone().into(),
         ),
     ]
     .into_iter()


### PR DESCRIPTION
This pull request includes updates to the `src/crypto/keymanager/external_keymanager/utils.rs` file to enhance the security and functionality of the key manager header.

Security improvements:

* [`src/crypto/keymanager/external_keymanager/utils.rs`](diffhunk://#diff-1f0c9447f190009fcda42401b68cdccad713002f46f1f29a6d7d013c45b56eaeL5-R7): Added the `Mask` import from the `masking` crate and used the `into_masked` method to mask the `broken_master_key` in the `get_key_manager_header` function. [[1]](diffhunk://#diff-1f0c9447f190009fcda42401b68cdccad713002f46f1f29a6d7d013c45b56eaeL5-R7) [[2]](diffhunk://#diff-1f0c9447f190009fcda42401b68cdccad713002f46f1f29a6d7d013c45b56eaeL23-R28)

Functionality enhancements:

* [`src/crypto/keymanager/external_keymanager/utils.rs`](diffhunk://#diff-1f0c9447f190009fcda42401b68cdccad713002f46f1f29a6d7d013c45b56eaeL23-R28): Added the `X_TENANT_ID` header to the `get_key_manager_header` function, using the tenant ID from the `tenant_app_state.config`.