### PR TITLE
fix: add console filters for json logs

### DIFF
--- a/src/logger/setup.rs
+++ b/src/logger/setup.rs
@@ -55,7 +55,8 @@ pub fn setup(
             }
             config::LogFormat::Json => {
                 error_stack::Report::set_color_mode(error_stack::fmt::ColorMode::None);
-                let logging_layer = FormattingLayer::new(service_name, console_writer);
+                let logging_layer =
+                    FormattingLayer::new(service_name, console_writer).with_filter(console_filter);
                 subscriber.with(logging_layer).init();
             }
         }


### PR DESCRIPTION
This pull request includes a change to the `setup` function in the `src/logger/setup.rs` file to enhance the logging configuration by adding a filter to the logging layer.

Logging configuration improvement:

* [`src/logger/setup.rs`](diffhunk://#diff-aae7f06039eaec6c526b32b89c2b9abc129b658918295df039d3abd2b3507adfL58-R59): Modified the `setup` function to include a filter (`console_filter`) in the `FormattingLayer` initialization for the JSON log format.