### PR TITLE
fix(logger): remove warn from subscriber

### DIFF
--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -192,7 +192,7 @@ where
                     if is_extra(key) && !explicit_entries_set.contains(key) {
                         map_serializer.serialize_entry(key, value)?;
                     } else {
-                        tracing::warn!(
+                        eprintln!(
                             "Attempting to log a reserved entry. It won't be added to the logs. key: {key:?}, value: {value:?}"
                         );
                     }

--- a/src/logger/storage.rs
+++ b/src/logger/storage.rs
@@ -31,7 +31,7 @@ impl<'a> Storage<'a> {
 
     pub fn record_value(&mut self, key: &'a str, value: serde_json::Value) {
         if super::formatter::IMPLICIT_KEYS.contains(key) {
-            tracing::warn!("{key} is a reserved entry. Skipping it. value: {value}");
+            eprintln!("{key} is a reserved entry. Skipping it. value: {value}");
         } else {
             self.values.insert(key, value);
         }


### PR DESCRIPTION
This pull request includes changes to the logging mechanism in the `src/logger` module. The most important changes involve replacing the `tracing::warn!` macro with `eprintln!` for logging reserved entries.

Changes to logging mechanism:

* [`src/logger/formatter.rs`](diffhunk://#diff-0d16e777a61aacf0f5983497f7d7f32ec199d3fec79daec73b95124989a255cdL195-R195): Replaced `tracing::warn!` with `eprintln!` for logging attempts to add reserved entries to the logs.
* [`src/logger/storage.rs`](diffhunk://#diff-a333b12c5a5910d99aafee2ee90bd49962457a2c7bd29b5b065443d1deebc160L34-R34): Replaced `tracing::warn!` with `eprintln!` for logging reserved entries when recording values.