### PR TITLE
fix error message in kms decryption

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -273,7 +273,7 @@ impl GlobalConfig {
                 tenant_secrets.public_key = secret_management_client
                     .get_secret(tenant_secrets.public_key.clone())
                     .await
-                    .change_context(error::ConfigurationError::KmsDecryptError("master_key"))?;
+                    .change_context(error::ConfigurationError::KmsDecryptError("public_key"))?;
             }
 
             self.secrets.locker_private_key = secret_management_client


### PR DESCRIPTION
This pull request includes a minor change to the `GlobalConfig` implementation in the `src/config.rs` file. The change modifies an error message to accurately reflect the context of the public key.

* [`src/config.rs`](diffhunk://#diff-cba64c21ab992eaad29fce147a08f4560a4769bc14682b8a96081a5fd02dbecdL276-R276): Changed the error message in the `change_context` method from "master_key" to "public_key" to accurately describe the context of the error.