### PR TITLE
refactor: add dev feature flag

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ rust-version = "1.78"
 [features]
 default = ["caching"]
 release = ["kms-aws", "middleware", "key_custodian", "limit", "kms-hashicorp-vault", "caching", "external_key_manager_mtls"]
+dev = ["kms-aws", "middleware", "key_custodian", "limit", "kms-hashicorp-vault", "caching"]
 kms-aws = ["dep:aws-config", "dep:aws-sdk-kms"]
 kms-hashicorp-vault = ["dep:vaultrs"]
 limit = []

--- a/src/bin/locker.rs
+++ b/src/bin/locker.rs
@@ -23,6 +23,10 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let global_app_state = GlobalAppState::new(global_config).await;
 
+    if cfg!(feature = "dev") {
+        eprintln!("This is a dev build, not for production use");
+    }
+
     tartarus::app::server_builder(global_app_state)
         .await
         .expect("Failed while building the server");

--- a/src/crypto/secrets_manager/managers/hcvault/implementers.rs
+++ b/src/crypto/secrets_manager/managers/hcvault/implementers.rs
@@ -15,6 +15,5 @@ impl SecretManager for HashiCorpVault {
         self.fetch::<Kv2, Secret<String>>(input.expose())
             .await
             .change_context(SecretsManagementError::FetchSecretFailed)
-            .map(Into::into)
     }
 }

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -329,7 +329,7 @@ impl<'a> From<&'a super::ApiClientError> for super::DataKeyCreationError {
             | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
             super::ApiClientError::IdentityParseFailed
             | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
-            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::RequestNotSent => Self::RequestSendFailed,
             super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
             super::ApiClientError::BadRequest(_) => Self::BadRequest,
             super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
@@ -364,7 +364,7 @@ impl<'a> From<&'a super::ApiClientError> for super::DataKeyTransferError {
             | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
             super::ApiClientError::IdentityParseFailed
             | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
-            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::RequestNotSent => Self::RequestSendFailed,
             super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
             super::ApiClientError::BadRequest(_) => Self::BadRequest,
             super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
@@ -415,7 +415,7 @@ impl<'a> From<&'a super::ApiClientError> for super::DataEncryptionError {
             | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
             super::ApiClientError::IdentityParseFailed
             | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
-            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::RequestNotSent => Self::RequestSendFailed,
             super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
             super::ApiClientError::BadRequest(_) => Self::BadRequest,
             super::ApiClientError::InternalServerError(_) => Self::InternalServerError,
@@ -450,7 +450,7 @@ impl<'a> From<&'a super::ApiClientError> for super::DataDecryptionError {
             | super::ApiClientError::UrlEncodingFailed => Self::RequestConstructionFailed,
             super::ApiClientError::IdentityParseFailed
             | super::ApiClientError::CertificateParseFailed { .. } => Self::CertificateParseFailed,
-            super::ApiClientError::RequestNotSent { .. } => Self::RequestSendFailed,
+            super::ApiClientError::RequestNotSent => Self::RequestSendFailed,
             super::ApiClientError::ResponseDecodingFailed => Self::ResponseDecodingFailed,
             super::ApiClientError::BadRequest(_) => Self::BadRequest,
             super::ApiClientError::InternalServerError(_) => Self::InternalServerError,


### PR DESCRIPTION
This pull request introduces a new feature flag, `dev`, in the `Cargo.toml` file to facilitate development-specific configurations.

Key change:

* Added a `dev` feature flag in `Cargo.toml` with dependencies including `kms-aws`, `middleware`, `key_custodian`, `limit`, `kms-hashicorp-vault`, and `caching`. This is likely intended to streamline development workflows by grouping commonly used features for development. (`[Cargo.tomlR13](diffhunk://#diff-2e9d962a08321605940b5a657135052fbcef87b5e360662bb527c96d9a615542R13)`)


![image](https://github.com/user-attachments/assets/f1962044-668d-497a-a5a2-5230f3bfbaba)
