### PR TITLE
build: bump edition to 2024

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,4 @@
+unstable_features = true
+
+group_imports = "StdExternalCrate" # Unstable
+imports_granularity = "Crate" # Unstable

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "tartarus"
 version = "0.1.3"
-edition = "2021"
+edition = "2024"
 default-run = "locker"
 rust-version = "1.85"
 

--- a/benches/encryption.rs
+++ b/benches/encryption.rs
@@ -8,7 +8,10 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use josekit::jwe;
 use rand::rngs::OsRng;
-use rsa::{pkcs8::EncodePrivateKey, pkcs8::EncodePublicKey, RsaPrivateKey, RsaPublicKey};
+use rsa::{
+    pkcs8::{EncodePrivateKey, EncodePublicKey},
+    RsaPrivateKey, RsaPublicKey,
+};
 use tartarus::crypto::encryption_manager::{
     encryption_interface::Encryption,
     managers::{aes, jw},

--- a/benches/encryption.rs
+++ b/benches/encryption.rs
@@ -5,12 +5,12 @@
     clippy::unwrap_in_result
 )]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use josekit::jwe;
 use rand::rngs::OsRng;
 use rsa::{
-    pkcs8::{EncodePrivateKey, EncodePublicKey},
     RsaPrivateKey, RsaPublicKey,
+    pkcs8::{EncodePrivateKey, EncodePublicKey},
 };
 use tartarus::crypto::encryption_manager::{
     encryption_interface::Encryption,

--- a/benches/hashing.rs
+++ b/benches/hashing.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::expect_used)]
 #![allow(clippy::missing_panics_doc)]
 
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
 use tartarus::crypto::hash_manager::{hash_interface::Encode, managers::sha::HmacSha512};
 
 const ITERATION: u32 = 14;

--- a/benches/luhn-test.rs
+++ b/benches/luhn-test.rs
@@ -1,5 +1,5 @@
-use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use tartarus::validations::{luhn, MAX_CARD_NUMBER_LENGTH};
+use criterion::{Criterion, black_box, criterion_group, criterion_main};
+use tartarus::validations::{MAX_CARD_NUMBER_LENGTH, luhn};
 
 #[allow(clippy::expect_used)]
 fn card_number_generator() -> Vec<u8> {

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -4,8 +4,8 @@ use masking::Maskable;
 #[cfg(feature = "external_key_manager")]
 use masking::PeekInterface;
 use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue},
     Response, StatusCode,
+    header::{HeaderMap, HeaderName, HeaderValue},
 };
 
 #[cfg(feature = "external_key_manager")]

--- a/src/api_client.rs
+++ b/src/api_client.rs
@@ -1,18 +1,18 @@
 use std::str::FromStr;
 
+use masking::Maskable;
+#[cfg(feature = "external_key_manager")]
+use masking::PeekInterface;
+use reqwest::{
+    header::{HeaderMap, HeaderName, HeaderValue},
+    Response, StatusCode,
+};
+
 #[cfg(feature = "external_key_manager")]
 use crate::config::ExternalKeyManagerConfig;
 use crate::{
     config::GlobalConfig,
     error::{self, ResultContainerExt},
-};
-use masking::Maskable;
-#[cfg(feature = "external_key_manager")]
-use masking::PeekInterface;
-use reqwest::StatusCode;
-use reqwest::{
-    header::{HeaderMap, HeaderName, HeaderValue},
-    Response,
 };
 
 pub type Headers = std::collections::HashSet<(String, Maskable<String>)>;

--- a/src/app.rs
+++ b/src/app.rs
@@ -1,3 +1,7 @@
+use std::sync::Arc;
+
+#[cfg(feature = "middleware")]
+use axum::middleware;
 use axum::{extract::Request, routing::post};
 use axum_server::tls_rustls::RustlsConfig;
 use error_stack::ResultExt;
@@ -5,12 +9,8 @@ use tower_http::trace as tower_trace;
 
 #[cfg(feature = "middleware")]
 use crate::middleware as custom_middleware;
-
-#[cfg(feature = "middleware")]
-use axum::middleware;
-
-use std::sync::Arc;
-
+#[cfg(feature = "caching")]
+use crate::storage::caching::Caching;
 use crate::{
     api_client::ApiClient,
     config::{self, GlobalConfig, TenantConfig},
@@ -20,9 +20,6 @@ use crate::{
     tenant::GlobalAppState,
     utils,
 };
-
-#[cfg(feature = "caching")]
-use crate::storage::caching::Caching;
 
 #[cfg(feature = "caching")]
 type Storage = Caching<storage::Storage>;

--- a/src/bin/utils.rs
+++ b/src/bin/utils.rs
@@ -4,14 +4,14 @@
 //! Simple Cli tool for generating keys to be used in the locker before deployment
 //!
 
-use std::io::{stdin, stdout, Read, Write};
+use std::io::{Read, Write, stdin, stdout};
 
 use josekit::jwe;
 use tartarus::{
     crypto::encryption_manager::{
         encryption_interface::Encryption,
         managers::{
-            aes::{generate_aes256_key, GcmAes256},
+            aes::{GcmAes256, generate_aes256_key},
             jw::JWEncryption,
         },
     },

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,3 +1,14 @@
+use std::{
+    collections::HashMap,
+    ops::{Deref, DerefMut},
+    path::PathBuf,
+};
+
+use error_stack::ResultExt;
+use masking::ExposeInterface;
+#[cfg(feature = "external_key_manager")]
+use masking::Secret;
+
 use crate::{
     api_client::ApiClientConfig,
     crypto::secrets_manager::{
@@ -5,15 +16,6 @@ use crate::{
     },
     error,
     logger::config::Log,
-};
-use error_stack::ResultExt;
-use masking::ExposeInterface;
-#[cfg(feature = "external_key_manager")]
-use masking::Secret;
-use std::{
-    collections::HashMap,
-    ops::{Deref, DerefMut},
-    path::PathBuf,
 };
 
 #[derive(Clone, serde::Deserialize, Debug)]

--- a/src/crypto/encryption_manager/managers/aes.rs
+++ b/src/crypto/encryption_manager/managers/aes.rs
@@ -1,9 +1,10 @@
+use error_stack::ResultExt;
+use ring::aead::{self, BoundKey};
+
 use crate::{
     crypto::encryption_manager::encryption_interface::Encryption,
     error::{self, ContainerError},
 };
-use error_stack::ResultExt;
-use ring::aead::{self, BoundKey};
 ///
 /// GcmAes256
 ///

--- a/src/crypto/encryption_manager/managers/jw.rs
+++ b/src/crypto/encryption_manager/managers/jw.rs
@@ -1,9 +1,10 @@
+use josekit::{jwe, jws};
+use masking::PeekInterface;
+
 use crate::{
     crypto::encryption_manager::encryption_interface::Encryption,
     error::{self, ContainerError},
 };
-use josekit::{jwe, jws};
-use masking::PeekInterface;
 
 pub struct JWEncryption {
     pub(crate) private_key: masking::Secret<String>,
@@ -176,9 +177,13 @@ pub fn verify_sign(jws_body: String, key: impl AsRef<[u8]>) -> Result<String, er
 mod tests {
     #![allow(clippy::unwrap_used, clippy::expect_used)]
 
-    use super::*;
     use rand::rngs::OsRng;
-    use rsa::{pkcs8::EncodePrivateKey, pkcs8::EncodePublicKey, RsaPrivateKey, RsaPublicKey};
+    use rsa::{
+        pkcs8::{EncodePrivateKey, EncodePublicKey},
+        RsaPrivateKey, RsaPublicKey,
+    };
+
+    use super::*;
 
     fn generate_rsa_key_pair() -> (String, String) {
         let mut rng = OsRng;

--- a/src/crypto/encryption_manager/managers/jw.rs
+++ b/src/crypto/encryption_manager/managers/jw.rs
@@ -179,8 +179,8 @@ mod tests {
 
     use rand::rngs::OsRng;
     use rsa::{
-        pkcs8::{EncodePrivateKey, EncodePublicKey},
         RsaPrivateKey, RsaPublicKey,
+        pkcs8::{EncodePrivateKey, EncodePublicKey},
     };
 
     use super::*;

--- a/src/crypto/keymanager.rs
+++ b/src/crypto/keymanager.rs
@@ -3,13 +3,13 @@ pub mod internal_keymanager;
 #[cfg(feature = "external_key_manager")]
 pub mod external_keymanager;
 
-pub use crate::config::ExternalKeyManagerConfig;
+use masking::{Secret, StrongSecret};
 
+pub use crate::config::ExternalKeyManagerConfig;
 use crate::{
     app::TenantAppState,
     error::{self, ContainerError},
 };
-use masking::{Secret, StrongSecret};
 
 #[async_trait::async_trait]
 pub trait KeyProvider: Send + Sync {

--- a/src/crypto/keymanager/external_keymanager.rs
+++ b/src/crypto/keymanager/external_keymanager.rs
@@ -8,6 +8,7 @@ use crate::{
     api_client::{ApiResponse, Method},
     app::TenantAppState,
     crypto::keymanager::{
+        CryptoOperationsManager,
         external_keymanager::{
             self,
             types::{
@@ -16,11 +17,10 @@ use crate::{
                 DateEncryptionResponse, DecryptedData, EncryptedData,
             },
         },
-        CryptoOperationsManager,
     },
     error::{self, ContainerError, NotFoundError},
     routes::health,
-    storage::{types::Entity, EntityInterface},
+    storage::{EntityInterface, types::Entity},
 };
 
 pub async fn create_key_in_key_manager(

--- a/src/crypto/keymanager/external_keymanager.rs
+++ b/src/crypto/keymanager/external_keymanager.rs
@@ -1,8 +1,9 @@
 pub mod types;
 pub mod utils;
 
-pub use crate::config::ExternalKeyManagerConfig;
+use masking::{Secret, StrongSecret};
 
+pub use crate::config::ExternalKeyManagerConfig;
 use crate::{
     api_client::{ApiResponse, Method},
     app::TenantAppState,
@@ -21,7 +22,6 @@ use crate::{
     routes::health,
     storage::{types::Entity, EntityInterface},
 };
-use masking::{Secret, StrongSecret};
 
 pub async fn create_key_in_key_manager(
     tenant_app_state: &TenantAppState,

--- a/src/crypto/keymanager/external_keymanager/types.rs
+++ b/src/crypto/keymanager/external_keymanager/types.rs
@@ -1,15 +1,17 @@
-use crate::{
-    crypto::{self, consts::BASE64_ENGINE},
-    error::{self, ResultContainerExt},
-    storage::{consts, types::Encrypted, utils},
-};
+use std::fmt;
+
 use base64::Engine;
 use masking::{ExposeInterface, PeekInterface, Secret, StrongSecret};
 use serde::{
     de::{self, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
 };
-use std::fmt;
+
+use crate::{
+    crypto::{self, consts::BASE64_ENGINE},
+    error::{self, ResultContainerExt},
+    storage::{consts, types::Encrypted, utils},
+};
 
 #[derive(Serialize, Deserialize, Debug, Eq, PartialEq, Clone)]
 pub struct DataKeyCreateRequest {

--- a/src/crypto/keymanager/external_keymanager/types.rs
+++ b/src/crypto/keymanager/external_keymanager/types.rs
@@ -3,8 +3,8 @@ use std::fmt;
 use base64::Engine;
 use masking::{ExposeInterface, PeekInterface, Secret, StrongSecret};
 use serde::{
-    de::{self, Unexpected, Visitor},
     Deserialize, Deserializer, Serialize, Serializer,
+    de::{self, Unexpected, Visitor},
 };
 
 use crate::{

--- a/src/crypto/keymanager/external_keymanager/utils.rs
+++ b/src/crypto/keymanager/external_keymanager/utils.rs
@@ -4,8 +4,7 @@ use base64::Engine;
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
 use masking::{Mask, Maskable};
 
-use crate::storage::consts::X_TENANT_ID;
-use crate::{app::TenantAppState, crypto::consts::BASE64_ENGINE};
+use crate::{app::TenantAppState, crypto::consts::BASE64_ENGINE, storage::consts::X_TENANT_ID};
 
 pub fn get_key_manager_header(
     tenant_app_state: &TenantAppState,

--- a/src/crypto/secrets_manager/managers/aws_kms/core.rs
+++ b/src/crypto/secrets_manager/managers/aws_kms/core.rs
@@ -1,9 +1,9 @@
 //! Interactions with the AWS KMS SDK
 
 use aws_config::meta::region::RegionProviderChain;
-use aws_sdk_kms::{config::Region, primitives::Blob, Client};
+use aws_sdk_kms::{Client, config::Region, primitives::Blob};
 use base64::Engine;
-use error_stack::{report, ResultExt};
+use error_stack::{ResultExt, report};
 
 use crate::{crypto::consts::BASE64_ENGINE, error::ConfigurationError, logger};
 

--- a/src/crypto/secrets_manager/secrets_management.rs
+++ b/src/crypto/secrets_manager/secrets_management.rs
@@ -8,7 +8,6 @@ use crate::crypto::secrets_manager::managers::aws_kms::core::{AwsKmsClient, AwsK
 use crate::crypto::secrets_manager::managers::hcvault::core::{
     HashiCorpVault, HashiCorpVaultConfig,
 };
-
 use crate::{
     crypto::secrets_manager::{
         managers::hollow::core::NoEncryption,

--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -14,10 +14,10 @@ use serde_json::Value;
 use time::format_description::well_known::Iso8601;
 use tracing::{Event, Metadata, Subscriber};
 use tracing_subscriber::{
+    Layer,
     fmt::MakeWriter,
     layer::Context,
     registry::{LookupSpan, SpanRef},
-    Layer,
 };
 
 use super::storage::Storage;

--- a/src/logger/formatter.rs
+++ b/src/logger/formatter.rs
@@ -11,8 +11,6 @@ use std::{
 use once_cell::sync::Lazy;
 use serde::ser::{SerializeMap, Serializer};
 use serde_json::Value;
-
-use super::storage::Storage;
 use time::format_description::well_known::Iso8601;
 use tracing::{Event, Metadata, Subscriber};
 use tracing_subscriber::{
@@ -21,6 +19,8 @@ use tracing_subscriber::{
     registry::{LookupSpan, SpanRef},
     Layer,
 };
+
+use super::storage::Storage;
 
 // TODO: Documentation coverage for this crate
 

--- a/src/logger/setup.rs
+++ b/src/logger/setup.rs
@@ -1,7 +1,7 @@
 //! Setup logging subsystem.
 
 use tracing_appender::non_blocking::WorkerGuard;
-use tracing_subscriber::{fmt, prelude::*, util::SubscriberInitExt, EnvFilter, Layer};
+use tracing_subscriber::{EnvFilter, Layer, fmt, prelude::*, util::SubscriberInitExt};
 
 use super::{config, formatter::FormattingLayer, storage::StorageSubscription};
 

--- a/src/logger/storage.rs
+++ b/src/logger/storage.rs
@@ -5,11 +5,11 @@
 use std::{collections::HashMap, fmt, time::Instant};
 
 use tracing::{
+    Id, Subscriber,
     field::{Field, Visit},
     span::{Attributes, Record},
-    Id, Subscriber,
 };
-use tracing_subscriber::{layer::Context, Layer};
+use tracing_subscriber::{Layer, layer::Context};
 
 /// Storage to store key value pairs of spans.
 #[derive(Clone, Debug)]

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,6 +1,6 @@
 use axum::{
     body::Body,
-    http::{request, response, Request},
+    http::{Request, request, response},
     middleware::Next,
 };
 use http_body_util::BodyExt;

--- a/src/middleware.rs
+++ b/src/middleware.rs
@@ -1,18 +1,19 @@
+use axum::{
+    body::Body,
+    http::{request, response, Request},
+    middleware::Next,
+};
+use http_body_util::BodyExt;
+use josekit::jwe;
+
 use crate::{
     crypto::encryption_manager::{
         encryption_interface::Encryption,
         managers::jw::{self, JWEncryption},
     },
+    custom_extractors::TenantStateResolver,
     error::{self, ContainerError, ResultContainerExt},
 };
-
-use crate::custom_extractors::TenantStateResolver;
-use axum::body::Body;
-use axum::http::{request, response};
-use axum::{http::Request, middleware::Next};
-
-use http_body_util::BodyExt;
-use josekit::jwe;
 
 /// Middleware providing implementation to perform JWE + JWS encryption and decryption around the
 /// card APIs

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -1,10 +1,10 @@
 use std::sync::Arc;
 
-use axum::{routing::post, Json};
-
 #[cfg(feature = "limit")]
 use axum::{error_handling::HandleErrorLayer, response::IntoResponse};
+use axum::{routing::post, Json};
 
+use self::types::Validation;
 use crate::{
     crypto::{hash_manager::managers::sha::Sha512, keymanager},
     custom_extractors::TenantStateResolver,
@@ -14,8 +14,6 @@ use crate::{
     tenant::GlobalAppState,
     utils,
 };
-
-use self::types::Validation;
 
 pub mod crypto_operation;
 mod transformers;

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -1,8 +1,8 @@
 use std::sync::Arc;
 
+use axum::{Json, routing::post};
 #[cfg(feature = "limit")]
 use axum::{error_handling::HandleErrorLayer, response::IntoResponse};
-use axum::{routing::post, Json};
 
 use self::types::Validation;
 use crate::{

--- a/src/routes/data/crypto_operation.rs
+++ b/src/routes/data/crypto_operation.rs
@@ -6,9 +6,9 @@ use crate::{
     error::{self, ContainerError, ResultContainerExt},
     routes::{data::types, routes_v2::data::types as types_v2},
     storage::{
-        storage_v2::{types::VaultNew, VaultInterface},
-        types::{Locker, LockerNew},
         LockerInterface,
+        storage_v2::{VaultInterface, types::VaultNew},
+        types::{Locker, LockerNew},
     },
 };
 

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -1,12 +1,11 @@
 use masking::{ExposeInterface, PeekInterface};
 
+use super::types::{self, DataDuplicationCheck};
 use crate::{
     crypto::hash_manager::hash_interface::Encode,
     error::{self, ContainerError, ResultContainerExt},
     storage,
 };
-
-use super::types::{self, DataDuplicationCheck};
 
 impl From<(Option<DataDuplicationCheck>, storage::types::Locker)>
     for super::types::StoreCardResponse

--- a/src/routes/data/transformers.rs
+++ b/src/routes/data/transformers.rs
@@ -86,10 +86,10 @@ pub fn get_hash<T>(
 ) -> Result<Vec<u8>, ContainerError<error::ApiError>>
 where
     T: Encode<
-        Vec<u8>,
-        Vec<u8>,
-        ReturnType<Vec<u8>> = Result<Vec<u8>, error::ContainerError<error::CryptoError>>,
-    >,
+            Vec<u8>,
+            Vec<u8>,
+            ReturnType<Vec<u8>> = Result<Vec<u8>, error::ContainerError<error::CryptoError>>,
+        >,
 {
     let data = match request {
         types::Data::EncData { enc_card_data } => enc_card_data,

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::{routing::get, Json};
+use axum::{Json, routing::get};
 
 #[cfg(feature = "external_key_manager")]
 use crate::{crypto::keymanager, logger};

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -1,12 +1,12 @@
 use std::sync::Arc;
 
-use crate::tenant::GlobalAppState;
-#[cfg(feature = "external_key_manager")]
-use crate::{crypto::keymanager, logger};
-
 use axum::{routing::get, Json};
 
-use crate::{custom_extractors::TenantStateResolver, error, storage::TestInterface};
+#[cfg(feature = "external_key_manager")]
+use crate::{crypto::keymanager, logger};
+use crate::{
+    custom_extractors::TenantStateResolver, error, storage::TestInterface, tenant::GlobalAppState,
+};
 
 ///
 /// Function for registering routes that is specifically handling the health apis

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use axum::{extract::State, routing::post, Json};
+use axum::{Json, extract::State, routing::post};
 use error_stack::ResultExt;
 
 use crate::{

--- a/src/routes/key_migration.rs
+++ b/src/routes/key_migration.rs
@@ -17,9 +17,9 @@ use crate::{
     error::{self, ContainerError, ResultContainerExt},
     logger,
     storage::{
-        consts,
+        EntityInterface, MerchantInterface, consts,
         types::{Entity, Merchant},
-        utils, EntityInterface, MerchantInterface,
+        utils,
     },
 };
 

--- a/src/routes/routes_v2/data.rs
+++ b/src/routes/routes_v2/data.rs
@@ -1,5 +1,4 @@
-use axum::extract::Query;
-use axum::Json;
+use axum::{extract::Query, Json};
 use error_stack::ResultExt;
 use masking::PeekInterface;
 pub mod types;

--- a/src/routes/routes_v2/data.rs
+++ b/src/routes/routes_v2/data.rs
@@ -1,4 +1,4 @@
-use axum::{extract::Query, Json};
+use axum::{Json, extract::Query};
 use error_stack::ResultExt;
 use masking::PeekInterface;
 pub mod types;

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,11 +1,11 @@
 use std::sync::Arc;
 
 use diesel_async::{
+    AsyncPgConnection,
     pooled_connection::{
         self,
         deadpool::{Object, Pool},
     },
-    AsyncPgConnection,
 };
 use error_stack::ResultExt;
 use masking::{PeekInterface, Secret};

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -1,9 +1,3 @@
-use crate::{
-    config::Database,
-    crypto::encryption_manager::encryption_interface::Encryption,
-    error::{self, ContainerError},
-};
-
 use std::sync::Arc;
 
 use diesel_async::{
@@ -15,6 +9,12 @@ use diesel_async::{
 };
 use error_stack::ResultExt;
 use masking::{PeekInterface, Secret};
+
+use crate::{
+    config::Database,
+    crypto::encryption_manager::encryption_interface::Encryption,
+    error::{self, ContainerError},
+};
 
 #[cfg(feature = "caching")]
 pub mod caching;

--- a/src/storage/caching/merchant.rs
+++ b/src/storage/caching/merchant.rs
@@ -1,10 +1,10 @@
+use futures_util::TryFutureExt;
+
 use crate::{
     crypto::encryption_manager::managers::aes,
     error::{ContainerError, NotFoundError},
     storage::{self, types},
 };
-
-use futures_util::TryFutureExt;
 
 impl<T> storage::MerchantInterface for super::Caching<T>
 where

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,20 +1,18 @@
-use diesel::BoolExpressionMethods;
-use diesel::{associations::HasTable, ExpressionMethods, QueryDsl};
+use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
 use diesel_async::{AsyncConnection, RunQueryDsl};
-use masking::ExposeInterface;
-use masking::Secret;
+use masking::{ExposeInterface, Secret};
 
+use super::{
+    consts, schema, types,
+    types::{StorageDecryption, StorageEncryption},
+    utils, LockerInterface, MerchantInterface, Storage,
+};
 use crate::{
     crypto::{
         encryption_manager::managers::aes,
         hash_manager::{hash_interface::Encode, managers::sha::HmacSha512},
     },
     error::{self, ContainerError, ResultContainerExt},
-};
-
-use super::{
-    consts, schema, types, types::StorageDecryption, types::StorageEncryption, utils,
-    LockerInterface, MerchantInterface, Storage,
 };
 
 impl MerchantInterface for Storage {

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,11 +1,11 @@
-use diesel::{associations::HasTable, BoolExpressionMethods, ExpressionMethods, QueryDsl};
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use diesel_async::{AsyncConnection, RunQueryDsl};
 use masking::{ExposeInterface, Secret};
 
 use super::{
-    consts, schema, types,
+    LockerInterface, MerchantInterface, Storage, consts, schema, types,
     types::{StorageDecryption, StorageEncryption},
-    utils, LockerInterface, MerchantInterface, Storage,
+    utils,
 };
 use crate::{
     crypto::{

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -1,15 +1,15 @@
 use diesel::{
-    associations::HasTable, query_dsl::methods::FilterDsl, BoolExpressionMethods, ExpressionMethods,
+    BoolExpressionMethods, ExpressionMethods, associations::HasTable, query_dsl::methods::FilterDsl,
 };
 use diesel_async::RunQueryDsl;
 use masking::{ExposeInterface, Secret};
 
-use super::{types, VaultInterface};
+use super::{VaultInterface, types};
 use crate::{
     crypto::encryption_manager::managers::aes::GcmAes256,
     error::{self, ContainerError, ResultContainerExt},
     logger,
-    storage::{schema, Storage},
+    storage::{Storage, schema},
 };
 
 impl VaultInterface for Storage {

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -4,14 +4,13 @@ use diesel::{
 use diesel_async::RunQueryDsl;
 use masking::{ExposeInterface, Secret};
 
+use super::{types, VaultInterface};
 use crate::{
     crypto::encryption_manager::managers::aes::GcmAes256,
     error::{self, ContainerError, ResultContainerExt},
     logger,
     storage::{schema, Storage},
 };
-
-use super::{types, VaultInterface};
 
 impl VaultInterface for Storage {
     type Algorithm = GcmAes256;

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -6,13 +6,12 @@ use diesel::{
 };
 use masking::{ExposeInterface, PeekInterface, Secret, StrongSecret};
 
+use super::schema;
 use crate::{
     crypto::encryption_manager::{encryption_interface::Encryption, managers::aes::GcmAes256},
     error,
     routes::data::types::{StoreCardRequest, Validation},
 };
-
-use super::schema;
 
 #[derive(Debug, Identifiable, Queryable)]
 #[diesel(table_name = schema::merchant)]

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -1,8 +1,9 @@
 use diesel::{
+    AsExpression, Identifiable, Insertable, Queryable,
     backend::Backend,
     deserialize::{self, FromSql},
     serialize::ToSql,
-    sql_types, AsExpression, Identifiable, Insertable, Queryable,
+    sql_types,
 };
 use masking::{ExposeInterface, PeekInterface, Secret, StrongSecret};
 


### PR DESCRIPTION
### Description

This PR involves 2 changes:

- Adds a `.rustfmt.toml` config file
- Bumps the edition in `Cargo.toml` from 2021 to 2024

In addition to these 2 changes, the PR just formats code, in accordance with the new rustfmt config file and [2024 edition style guide](https://doc.rust-lang.org/stable/edition-guide/rust-2024/rustfmt-style-edition.html).