### PR TITLE
feat(fingerprint): support caller-supplied fingerprint ID via `x-fingerprint-id` header

### DIFF
--- a/src/custom_extractors.rs
+++ b/src/custom_extractors.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use axum::{async_trait, extract::FromRequestParts, http::request::Parts};
+use hyperswitch_masking::Secret;
 
 use crate::{
     app::TenantAppState,
@@ -55,5 +56,38 @@ impl FromRequestParts<Arc<GlobalAppState>> for TenantId {
         state.is_custodian_unlocked(&tenant_id).await?;
 
         Ok(Self(tenant_id))
+    }
+}
+
+/// Optionally reads `x-fingerprint-id` from request headers.
+/// If present, the value must be exactly 20 alphanumeric (0-9 a-z A-Z) characters,
+/// matching the format of server-generated fingerprint IDs.
+#[derive(Debug)]
+pub struct OptionalFingerprintId(pub Option<Secret<String>>);
+
+#[async_trait]
+impl FromRequestParts<Arc<GlobalAppState>> for OptionalFingerprintId {
+    type Rejection = ContainerError<ApiError>;
+
+    async fn from_request_parts(
+        parts: &mut Parts,
+        _state: &Arc<GlobalAppState>,
+    ) -> Result<Self, Self::Rejection> {
+        let fingerprint_id = parts
+            .headers
+            .get(consts::X_FINGERPRINT_ID)
+            .and_then(|h| h.to_str().ok())
+            .map(|s| -> Result<Secret<String>, ContainerError<ApiError>> {
+                if s.len() != consts::ID_LENGTH || !s.chars().all(|c| c.is_ascii_alphanumeric()) {
+                    Err(ContainerError::from(ApiError::ValidationError(
+                        "x-fingerprint-id must be exactly 20 alphanumeric characters",
+                    )))
+                } else {
+                    Ok(Secret::new(s.to_string()))
+                }
+            })
+            .transpose()?;
+
+        Ok(Self(fingerprint_id))
     }
 }

--- a/src/routes/data.rs
+++ b/src/routes/data.rs
@@ -7,7 +7,7 @@ use axum::{error_handling::HandleErrorLayer, response::IntoResponse};
 use self::types::Validation;
 use crate::{
     crypto::{hash_manager::managers::sha::Sha512, keymanager},
-    custom_extractors::TenantStateResolver,
+    custom_extractors::{OptionalFingerprintId, TenantStateResolver},
     error::{self, ContainerError, ResultContainerExt},
     logger,
     storage::{FingerprintInterface, HashInterface, LockerInterface},
@@ -219,11 +219,12 @@ pub async fn retrieve_card(
 /// `/cards/fingerprint` handling the creation and retrieval of card fingerprint
 pub async fn get_or_insert_fingerprint(
     TenantStateResolver(tenant_app_state): TenantStateResolver,
+    OptionalFingerprintId(fingerprint_id): OptionalFingerprintId,
     Json(request): Json<types::FingerprintRequest>,
 ) -> Result<Json<types::FingerprintResponse>, ContainerError<error::ApiError>> {
     let fingerprint = tenant_app_state
         .db
-        .get_or_insert_fingerprint(request.data, request.key)
+        .get_or_insert_fingerprint(request.data, request.key, fingerprint_id)
         .await?;
 
     let response = Json(fingerprint.into());

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -230,6 +230,7 @@ pub(crate) trait FingerprintInterface {
         &self,
         data: Secret<String>,
         key: Secret<String>,
+        fingerprint_id: Option<Secret<String>>,
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>>;
 }
 

--- a/src/storage/caching/fingerprint.rs
+++ b/src/storage/caching/fingerprint.rs
@@ -43,8 +43,12 @@ where
         &self,
         data: Secret<String>,
         key: Secret<String>,
+        fingerprint_id: Option<Secret<String>>,
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>> {
-        let output = self.inner.get_or_insert_fingerprint(data, key).await?;
+        let output = self
+            .inner
+            .get_or_insert_fingerprint(data, key, fingerprint_id)
+            .await?;
         self.cache_data::<types::Fingerprint>(
             output.fingerprint_hash.clone().expose(),
             output.clone(),

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -13,6 +13,8 @@ pub const ID_LENGTH: usize = 20;
 pub const X_TENANT_ID: &str = "x-tenant-id";
 /// Header key for request ID
 pub const X_REQUEST_ID: &str = "x-request-id";
+/// Header key for caller-supplied fingerprint ID (optional)
+pub const X_FINGERPRINT_ID: &str = "x-fingerprint-id";
 /// Header Constants
 pub mod headers {
     pub const CONTENT_TYPE: &str = "Content-Type";

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -351,6 +351,7 @@ impl super::FingerprintInterface for Storage {
         &self,
         data: Secret<String>,
         key: Secret<String>,
+        fingerprint_id: Option<Secret<String>>,
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>> {
         let algo = HmacSha512::<1>::new(key.map(|inner| inner.into_bytes()));
 
@@ -360,20 +361,39 @@ impl super::FingerprintInterface for Storage {
             .find_by_fingerprint_hash(fingerprint_hash.clone())
             .await?;
         match output {
+            // Hash already exists: return the stored fingerprint regardless of any
+            // caller-supplied id — the hash is the canonical deduplication key.
             Some(inner) => Ok(inner),
             None => {
+                let id = fingerprint_id
+                    .unwrap_or_else(|| utils::generate_nano_id(consts::ID_LENGTH).into());
+                let cloned_hash = fingerprint_hash.clone();
                 let mut conn = self.get_conn().await?;
-                let query = diesel::insert_into(types::Fingerprint::table()).values(
-                    types::FingerprintTableNew {
-                        fingerprint_hash,
-                        fingerprint_id: utils::generate_nano_id(consts::ID_LENGTH).into(),
-                    },
-                );
 
-                Ok(query
-                    .get_result(&mut conn)
-                    .await
-                    .change_error(error::StorageError::InsertError)?)
+                let insert_result: Result<types::Fingerprint, diesel::result::Error> =
+                    diesel::insert_into(types::Fingerprint::table())
+                        .values(types::FingerprintTableNew {
+                            fingerprint_hash,
+                            fingerprint_id: id,
+                        })
+                        .get_result(&mut conn)
+                        .await;
+
+                match insert_result {
+                    Ok(inner) => Ok(inner),
+                    // Race condition: a concurrent request inserted the same hash first.
+                    // Re-read by hash and return the winner row.
+                    Err(diesel::result::Error::DatabaseError(
+                        diesel::result::DatabaseErrorKind::UniqueViolation,
+                        _,
+                    )) => self
+                        .find_by_fingerprint_hash(cloned_hash)
+                        .await?
+                        .ok_or_else(|| {
+                            ContainerError::from(error::FingerprintDBError::DBInsertError)
+                        }),
+                    Err(error) => Err(error).change_error(error::StorageError::InsertError)?,
+                }
             }
         }
     }


### PR DESCRIPTION
Add an optional x-fingerprint-id request header to POST /data/fingerprint.

Behaviour:
- Header absent,  hash not found -> generate ID, insert, return (existing flow unchanged)
- Header absent,  hash found     -> return stored ID
- Header present (valid),   hash not found -> insert using caller-supplied ID, return it
- Header present (valid),   hash found     -> return stored ID, header ignored
- Header present (invalid)                -> 422 ValidationError before any DB call

Header format: exactly 20 alphanumeric characters (0-9 a-z A-Z).

## Test cases
## Scenario A — hash not found, no header (server generates ID)

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -d '{"data":"4111111111111111","key":"mysecretkey"}'
```

**Response `200 OK`**
```json
{"fingerprint_id":"DxgSyhrG6RTnCUZmcLky"}
```

> The server generated and stored a fresh 20-char ID for this `(data, key)` pair.

---

## Scenario B — hash not found, caller supplies ID

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -H "x-fingerprint-id: MyCustomId0123456789" \
  -d '{"data":"5500005555555559","key":"mysecretkey"}'
```

**Response `200 OK`**
```json
{"fingerprint_id":"MyCustomId0123456789"}
```

> The record was inserted using the caller-supplied ID.

---

## Scenario C — hash already exists, no header (returns stored ID)

Same request as Scenario A:

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -d '{"data":"4111111111111111","key":"mysecretkey"}'
```

**Response `200 OK`**
```json
{"fingerprint_id":"DxgSyhrG6RTnCUZmcLky"}
```

> Hash was found; the originally stored ID is returned and nothing is inserted.

---

## Scenario D — hash already exists, header present (header ignored)

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -H "x-fingerprint-id: SomeOtherId123456789" \
  -d '{"data":"4111111111111111","key":"mysecretkey"}'
```

**Response `200 OK`**
```json
{"fingerprint_id":"DxgSyhrG6RTnCUZmcLky"}
```

> The `x-fingerprint-id` header is ignored because the hash already has a stored record.

---

## Scenario E — invalid header value

### Too short — `TooShort123456789` (17 chars)

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -H "x-fingerprint-id: TooShort123456789" \
  -d '{"data":"4111111111111111","key":"mysecretkey"}'
```

**Response**
```json
{"code":"TE_03","message":"Failed while validation: x-fingerprint-id must be exactly 20 alphanumeric characters","data":null}
```

### Non-alphanumeric characters — `bad-id-val-here12345` (20 chars, contains `-`)

```bash
curl -X POST http://localhost:3000/data/fingerprint \
  -H "Content-Type: application/json" \
  -H "x-tenant-id: public" \
  -H "x-fingerprint-id: bad-id-val-here12345" \
  -d '{"data":"4111111111111111","key":"mysecretkey"}'
```

**Response**
```json
{"code":"TE_03","message":"Failed while validation: x-fingerprint-id must be exactly 20 alphanumeric characters","data":null}
```



