### PR TITLE
refactor: rename package from `tartarus` to `hyperswitch-card-vault`

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run `cargo hack`
         shell: bash
-        run: cargo hack check --each-feature --all-targets --package tartarus
+        run: cargo hack check --each-feature --all-targets --package hyperswitch-card-vault
 
   test:
     name: Run tests on stable toolchain

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -99,7 +99,7 @@ jobs:
 
       - name: Run `cargo hack`
         shell: bash
-        run: cargo hack check --each-feature --all-targets --package hyperswitch-card-vault
+        run: cargo hack check --each-feature --all-targets --package hyperswitch_card_vault
 
   test:
     name: Run tests on stable toolchain

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run `cargo hack`
         shell: bash
-        run: cargo hack check --each-feature --all-targets --package hyperswitch-card-vault
+        run: cargo hack check --each-feature --all-targets --package hyperswitch_card_vault
 
   test:
     name: Run tests on stable toolchain

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -60,7 +60,7 @@ jobs:
 
       - name: Run `cargo hack`
         shell: bash
-        run: cargo hack check --each-feature --all-targets --package tartarus
+        run: cargo hack check --each-feature --all-targets --package hyperswitch-card-vault
 
   test:
     name: Run tests on stable toolchain

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,7 +2930,7 @@ dependencies = [
 ]
 
 [[package]]
-name = "hyperswitch-card-vault"
+name = "hyperswitch_card_vault"
 version = "0.1.3"
 dependencies = [
  "argh",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2930,6 +2930,60 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyperswitch-card-vault"
+version = "0.1.3"
+dependencies = [
+ "argh",
+ "async-trait",
+ "aws-config",
+ "aws-sdk-kms",
+ "axum",
+ "axum-server",
+ "axum-test",
+ "base64 0.22.1",
+ "build_info",
+ "bytes",
+ "config",
+ "console-subscriber",
+ "criterion",
+ "diesel",
+ "diesel-async",
+ "digest",
+ "error-stack",
+ "futures",
+ "futures-util",
+ "gethostname 0.5.0",
+ "hex",
+ "http-body-util",
+ "hyper 1.4.1",
+ "hyperswitch_masking",
+ "josekit",
+ "log_utils",
+ "moka",
+ "nanoid",
+ "once_cell",
+ "rand",
+ "reqwest 0.12.7",
+ "ring",
+ "rsa",
+ "rustc-hash 2.1.1",
+ "serde",
+ "serde_json",
+ "serde_path_to_error",
+ "thiserror 1.0.63",
+ "time",
+ "tokio",
+ "tower 0.5.0",
+ "tower-http",
+ "tracing",
+ "tracing-appender",
+ "tracing-attributes",
+ "tracing-subscriber",
+ "uuid",
+ "vaultrs",
+]
+
+[[package]]
 name = "hyperswitch_masking"
 version = "0.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4941,60 +4995,6 @@ name = "tagptr"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
-
-[[package]]
-name = "tartarus"
-version = "0.1.3"
-dependencies = [
- "argh",
- "async-trait",
- "aws-config",
- "aws-sdk-kms",
- "axum",
- "axum-server",
- "axum-test",
- "base64 0.22.1",
- "build_info",
- "bytes",
- "config",
- "console-subscriber",
- "criterion",
- "diesel",
- "diesel-async",
- "digest",
- "error-stack",
- "futures",
- "futures-util",
- "gethostname 0.5.0",
- "hex",
- "http-body-util",
- "hyper 1.4.1",
- "hyperswitch_masking",
- "josekit",
- "log_utils",
- "moka",
- "nanoid",
- "once_cell",
- "rand",
- "reqwest 0.12.7",
- "ring",
- "rsa",
- "rustc-hash 2.1.1",
- "serde",
- "serde_json",
- "serde_path_to_error",
- "thiserror 1.0.63",
- "time",
- "tokio",
- "tower 0.5.0",
- "tower-http",
- "tracing",
- "tracing-appender",
- "tracing-attributes",
- "tracing-subscriber",
- "uuid",
- "vaultrs",
-]
 
 [[package]]
 name = "tempfile"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "hyperswitch-card-vault"
+name = "hyperswitch_card_vault"
 version = "0.1.3"
 edition = "2024"
 default-run = "locker"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [package]
-name = "tartarus"
+name = "hyperswitch-card-vault"
 version = "0.1.3"
 edition = "2024"
 default-run = "locker"

--- a/README.md
+++ b/README.md
@@ -1,19 +1,19 @@
-# Tartarus - Rust Locker
+# Hyperswitch Card Vault - Rust Locker
 
 
 ## Overview
 
-The Hyperswitch Card Vault (Tartarus) is a highly performant and a secure vault to save sensitive data such as payment card details, bank account details etc.
+The Hyperswitch Card Vault is a highly performant and a secure vault to save sensitive data such as payment card details, bank account details etc.
 
 It is designed in an polymorphic manner to handle and store any type of sensitive information making it highly scalable with extensive coverage of payment methods and processors.
 
-Tartarus is built with a GDPR compliant personal identifiable information (PII) storage and secure encryption algorithms to be fully compliant with PCI DSS requirements.
+Hyperswitch Card Vault is built with a GDPR compliant personal identifiable information (PII) storage and secure encryption algorithms to be fully compliant with PCI DSS requirements.
 
-Here's a quick guide to [Get Started](./docs/guides/setup.md) with setting up Tartarus.
+Here's a quick guide to [Get Started](./docs/guides/setup.md) with setting up Hyperswitch Card Vault.
 
-### How does Tartarus work?
+### How does Hyperswitch Card Vault work?
 
-- Your application will communicate with Tartarus via a middleware.
+- Your application will communicate with Hyperswitch Card Vault via a middleware.
 - All requests and responses to and from the middleware are signed and encrypted with the JWS and JWE algorithms.
 - The locker supports CRD APIs on the /data and /cards endpoints - <API Reference to be linked>
 - Cards are stored against the combination of merchant and customer identifiers.
@@ -30,4 +30,4 @@ Here's a quick guide to [Get Started](./docs/guides/setup.md) with setting up Ta
 
 ### Setup Guide
 
-Follow this guide to setup Tartarus - [Get Started](./docs/guides/setup.md)
+Follow this guide to setup Hyperswitch Card Vault - [Get Started](./docs/guides/setup.md)

--- a/benches/encryption.rs
+++ b/benches/encryption.rs
@@ -12,7 +12,7 @@ use rsa::{
     RsaPrivateKey, RsaPublicKey,
     pkcs8::{EncodePrivateKey, EncodePublicKey},
 };
-use tartarus::crypto::encryption_manager::{
+use hyperswitch_card_vault::crypto::encryption_manager::{
     encryption_interface::Encryption,
     managers::{aes, jw},
 };

--- a/benches/hashing.rs
+++ b/benches/hashing.rs
@@ -2,7 +2,7 @@
 #![allow(clippy::missing_panics_doc)]
 
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use tartarus::crypto::hash_manager::{hash_interface::Encode, managers::sha::HmacSha512};
+use hyperswitch_card_vault::crypto::hash_manager::{hash_interface::Encode, managers::sha::HmacSha512};
 
 const ITERATION: u32 = 14;
 

--- a/benches/luhn-test.rs
+++ b/benches/luhn-test.rs
@@ -1,5 +1,5 @@
 use criterion::{Criterion, black_box, criterion_group, criterion_main};
-use tartarus::validations::{MAX_CARD_NUMBER_LENGTH, luhn};
+use hyperswitch_card_vault::validations::{MAX_CARD_NUMBER_LENGTH, luhn};
 
 #[allow(clippy::expect_used)]
 fn card_number_generator() -> Vec<u8> {

--- a/docs/collection/hyperswitch-card-vault.postman_collection.json
+++ b/docs/collection/hyperswitch-card-vault.postman_collection.json
@@ -1,7 +1,7 @@
 {
 	"info": {
 		"_postman_id": "c4ca9eca-2446-4011-bab0-dc0813ff737e",
-		"name": "Tartarus",
+		"name": "Hyperswitch Card Vault",
 		"description": "The is the API collection to test the card vault.\n\nIf you are newly deploying the card vault application, by using the docker images available here [juspaydotin/hyperswitch-card-vault](). You be required to unlock the locker using the key custodian API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.1.0/collection.json",
 		"_exporter_id": "23503638"

--- a/docs/guides/testing.md
+++ b/docs/guides/testing.md
@@ -1,6 +1,6 @@
 ## Prerequisites for Locker API Testing
 
-A postman collection is included in `docs/collection/Tartarus.postman_collection.json` for testing the Locker API. The collection contains requests for all the endpoints of the Locker API.
+A postman collection is included in `docs/collection/hyperswitch-card-vault.postman_collection.json` for testing the Locker API. The collection contains requests for all the endpoints of the Locker API.
 
 Note: The requests in the Postman collection will not work when the `middleware` feature is enabled. This is because the requests need to be JWE (JSON Web Encryption) + JWS (JSON Web Signature) encrypted.
 

--- a/docs/openapi-v2/spec.yml
+++ b/docs/openapi-v2/spec.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.2"
 info:
-  title: Tartarus - OpenAPI 3.0
+  title: Hyperswitch Card Vault - OpenAPI 3.0
   description: |-
     This the the open API 3.0 specification for the card locker.
     This is used by the [hyperswitch](https://github.com/juspay/hyperswitch) for storing card information securely.

--- a/docs/openapi/spec.yml
+++ b/docs/openapi/spec.yml
@@ -1,6 +1,6 @@
 openapi: "3.0.2"
 info:
-  title: Tartarus - OpenAPI 3.0
+  title: Hyperswitch Card Vault - OpenAPI 3.0
   description: |-
     This the the open API 3.0 specification for the card locker.
     This is used by the [hyperswitch](https://github.com/juspay/hyperswitch) for storing card information securely.
@@ -283,7 +283,7 @@ components:
         nick_name:
           type: string
     FingerprintCardData:
-      type: object 
+      type: object
       properties:
         card_number:
           type: string

--- a/src/bin/locker.rs
+++ b/src/bin/locker.rs
@@ -1,15 +1,15 @@
-use tartarus::{logger, tenant::GlobalAppState};
+use hyperswitch_card_vault::{logger, tenant::GlobalAppState};
 
 #[allow(clippy::expect_used)]
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let mut global_config =
-        tartarus::config::GlobalConfig::new().expect("Failed while parsing config");
+        hyperswitch_card_vault::config::GlobalConfig::new().expect("Failed while parsing config");
 
     let _guard = logger::setup(
         &global_config.log,
-        tartarus::service_name!(),
-        [tartarus::service_name!(), "tower_http"],
+        hyperswitch_card_vault::service_name!(),
+        [hyperswitch_card_vault::service_name!(), "tower_http"],
     )
     .expect("Failed to initialize logging");
 
@@ -23,7 +23,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let global_app_state = GlobalAppState::new(global_config).await;
 
-    tartarus::app::server_builder(global_app_state)
+    hyperswitch_card_vault::app::server_builder(global_app_state)
         .await
         .expect("Failed while building the server");
 

--- a/src/bin/utils.rs
+++ b/src/bin/utils.rs
@@ -6,7 +6,6 @@
 
 use std::io::{Read, Write, stdin, stdout};
 
-use josekit::jwe;
 use hyperswitch_card_vault::{
     crypto::encryption_manager::{
         encryption_interface::Encryption,
@@ -17,6 +16,7 @@ use hyperswitch_card_vault::{
     },
     error,
 };
+use josekit::jwe;
 
 #[derive(argh::FromArgs, Debug)]
 /// Utilities to generate associated properties used by locker

--- a/src/bin/utils.rs
+++ b/src/bin/utils.rs
@@ -7,7 +7,7 @@
 use std::io::{Read, Write, stdin, stdout};
 
 use josekit::jwe;
-use tartarus::{
+use hyperswitch_card_vault::{
     crypto::encryption_manager::{
         encryption_interface::Encryption,
         managers::{

--- a/src/crypto/hash_manager/managers/sha.rs
+++ b/src/crypto/hash_manager/managers/sha.rs
@@ -23,8 +23,8 @@ impl Encode<Vec<u8>, Vec<u8>> for Sha512 {
 /// # Example
 ///
 ///```
-/// use tartarus::crypto::hash_manager::managers::sha::HmacSha512;
-/// use tartarus::crypto::hash_manager::hash_interface::Encode;
+/// use hyperswitch_card_vault::crypto::hash_manager::managers::sha::HmacSha512;
+/// use hyperswitch_card_vault::crypto::hash_manager::hash_interface::Encode;
 ///
 /// let data = "Hello, World!";
 /// let key = "key";
@@ -37,8 +37,8 @@ impl Encode<Vec<u8>, Vec<u8>> for Sha512 {
 ///
 /// ```compile_fail
 ///
-/// use tartarus::crypto::hash_manager::managers::sha::HmacSha512;
-/// use tartarus::crypto::hash_manager::hash_interface::Encode;
+/// use hyperswitch_card_vault::crypto::hash_manager::managers::sha::HmacSha512;
+/// use hyperswitch_card_vault::crypto::hash_manager::hash_interface::Encode;
 ///
 /// let key = "key";
 /// let algo = HmacSha512::<0>::new(key.as_bytes().to_vec().into());


### PR DESCRIPTION
## Summary

The repository was originally named **tartarus** and later renamed to **hyperswitch-card-vault**, but the Cargo package name and several code/doc references still used the old name. This PR renames the package and updates all remaining `tartarus` references for consistency.

## Changes

**Functional (build-affecting):**
- `Cargo.toml`: package `name` `tartarus` → `hyperswitch-card-vault` (lib crate is imported as `hyperswitch_card_vault` — Cargo normalizes hyphens to underscores)
- `Cargo.lock`: regenerated
- `src/bin/locker.rs`, `src/bin/utils.rs`: `use tartarus::` → `use hyperswitch_card_vault::`
- `benches/{luhn-test,hashing,encryption}.rs`: bench imports updated
- `src/crypto/hash_manager/managers/sha.rs`: rustdoc doctest imports updated
- `.github/workflows/{CI-pr,CI-push}.yml`: `--package tartarus` → `--package hyperswitch-card-vault`

**Cosmetic (docs):**
- `README.md`: product name updated to "Hyperswitch Card Vault"
- `docs/openapi/spec.yml`, `docs/openapi-v2/spec.yml`: OpenAPI titles
- `docs/collection/Tartarus.postman_collection.json` → `hyperswitch-card-vault.postman_collection.json` (renamed + `name` field), reference updated in `docs/guides/testing.md`

## Deployment impact

None. The binaries remain `locker`/`utils`, and the Docker image and database names never referenced `tartarus`.

## Verification

- `cargo build --all-targets` ✅ (produces `locker` and `utils` binaries)
- `cargo test` ✅ (full suite, incl. doctests)
- `rg -i tartarus` (excl. `target/`) → no matches

🤖 Generated with [Claude Code](https://claude.com/claude-code)