### PR TITLE
fix(config): fix failures in parsing metrics port from environment variables

### DIFF
--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -25,7 +25,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          client-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository with token
@@ -112,7 +112,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          client-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository with token

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -23,7 +23,7 @@ jobs:
       - name: Generate a token
         if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
@@ -110,7 +110,7 @@ jobs:
       - name: Generate a token
         if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -90,7 +90,7 @@ jobs:
         with:
           toolchain: "${{ env.rust_version }}"
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
@@ -151,7 +151,7 @@ jobs:
           tool: cargo-nextest
           checksum: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: Run clippy
         shell: bash

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -30,7 +30,7 @@ jobs:
 
       - name: Checkout repository with token
         if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -38,7 +38,7 @@ jobs:
 
       - name: Checkout repository for fork
         if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -71,7 +71,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -117,7 +117,7 @@ jobs:
 
       - name: Checkout repository with token
         if: ${{ github.event.pull_request.head.repo.full_name == github.event.pull_request.base.repo.full_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           ref: ${{ github.event.pull_request.head.ref }}
@@ -125,7 +125,7 @@ jobs:
 
       - name: Checkout repository for fork
         if: ${{ github.event.pull_request.head.repo.full_name != github.event.pull_request.base.repo.full_name }}
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -184,7 +184,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Spell check
         uses: crate-ci/typos@master

--- a/.github/workflows/CI-pr.yml
+++ b/.github/workflows/CI-pr.yml
@@ -93,9 +93,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.0
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-hack
+          tool: cargo-hack
+          checksum: true
 
       - name: Run `cargo hack`
         shell: bash
@@ -139,14 +140,16 @@ jobs:
           components: clippy
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-hack
+          tool: cargo-hack
+          checksum: true
 
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-nextest
+          tool: cargo-nextest
+          checksum: true
 
       - uses: Swatinem/rust-cache@v2.7.0
 

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -51,7 +51,7 @@ jobs:
         with:
           toolchain: "${{ env.rust_version }}"
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: Install cargo-hack
         uses: taiki-e/install-action@v2
@@ -95,7 +95,7 @@ jobs:
           tool: cargo-nextest
           checksum: true
 
-      - uses: Swatinem/rust-cache@v2.7.0
+      - uses: Swatinem/rust-cache@v2.9.1
 
       - name: Run clippy
         shell: bash

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install Rust
         uses: dtolnay/rust-toolchain@master
@@ -32,7 +32,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -69,7 +69,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install mold linker
         uses: rui314/setup-mold@v1
@@ -116,7 +116,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Spell check
         uses: crate-ci/typos@master

--- a/.github/workflows/CI-push.yml
+++ b/.github/workflows/CI-push.yml
@@ -54,9 +54,10 @@ jobs:
       - uses: Swatinem/rust-cache@v2.7.0
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-hack
+          tool: cargo-hack
+          checksum: true
 
       - name: Run `cargo hack`
         shell: bash
@@ -83,14 +84,16 @@ jobs:
           components: clippy
 
       - name: Install cargo-hack
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-hack
+          tool: cargo-hack
+          checksum: true
 
       - name: Install cargo-nextest
-        uses: baptiste0928/cargo-install@v2.2.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cargo-nextest
+          tool: cargo-nextest
+          checksum: true
 
       - uses: Swatinem/rust-cache@v2.7.0
 

--- a/.github/workflows/build-and-push-docker-image.yml
+++ b/.github/workflows/build-and-push-docker-image.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -12,7 +12,7 @@ jobs:
         id: generate_token
         uses: actions/create-github-app-token@v3
         with:
-          app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
+          client-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -16,7 +16,7 @@ jobs:
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}
 
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
         with:
           fetch-depth: 0
           token: ${{ steps.generate_token.outputs.token }}

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -27,16 +27,16 @@ jobs:
           toolchain: stable 2 weeks ago
 
       - name: Install cocogitto
-        uses: baptiste0928/cargo-install@v2.1.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: cocogitto
-          version: 5.4.0
+          tool: cocogitto@5.4.0
+          checksum: true
 
       - name: Install git-cliff
-        uses: baptiste0928/cargo-install@v2.1.0
+        uses: taiki-e/install-action@v2
         with:
-          crate: git-cliff
-          version: 2.7.0
+          tool: git-cliff@2.7.0
+          checksum: true
 
       - name: Set Git Configuration
         shell: bash

--- a/.github/workflows/release-new-version.yml
+++ b/.github/workflows/release-new-version.yml
@@ -10,7 +10,7 @@ jobs:
     steps:
       - name: Generate a token
         id: generate_token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.HYPERSWITCH_BOT_APP_ID }}
           private-key: ${{ secrets.HYPERSWITCH_BOT_APP_PRIVATE_KEY }}

--- a/src/config.rs
+++ b/src/config.rs
@@ -197,7 +197,11 @@ impl GlobalConfig {
 
         let config = Self::builder(&env)?
             .add_source(config::File::from(config_path).required(false))
-            .add_source(config::Environment::with_prefix("LOCKER").separator("__"))
+            .add_source(
+                config::Environment::with_prefix("LOCKER")
+                    .separator("__")
+                    .try_parsing(true),
+            )
             .build()?;
 
         serde_path_to_error::deserialize(config).map_err(|error| {


### PR DESCRIPTION
### Description

This PR fixes an issue in parsing metrics port from environment variables. If the application was run with a command like `LOCKER__METRICS__PORT=9090 cargo run`, we would notice the following error during application startup, which this PR fixes by calling `.try_parsing(true)`:

```text
thread 'main' (1) panicked at src/bin/locker.rs:7:61:
Failed while parsing config: invalid type: string "9090", expected u16
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

Additionally, this PR includes some CI changes aimed to reduce the time taken by CI workflows.