### PR TITLE
feat(storage): introduce reverse_lookup table

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /target
+.DS_Store

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/down.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/down.sql
@@ -1,0 +1,3 @@
+-- This file should undo anything in `up.sql`
+
+DROP TABLE IF EXISTS reverse_lookup;

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -4,7 +4,8 @@ CREATE TABLE IF NOT EXISTS reverse_lookup (
     lookup_id BYTEA NOT NULL PRIMARY KEY,
     secondary_key VARCHAR NOT NULL,
     partition_key VARCHAR NOT NULL,
-    source VARCHAR NOT NULL
+    source VARCHAR NOT NULL,
+    update_by VARCHAR NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS lookup_id_index ON reverse_lookup (lookup_id);

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -2,8 +2,8 @@
 
 CREATE TABLE IF NOT EXISTS reverse_lookup (
     lookup_id BYTEA NOT NULL PRIMARY KEY,
-    sk_id VARCHAR NOT NULL,
-    pk_id VARCHAR NOT NULL,
+    secondary_key VARCHAR NOT NULL,
+    partition_key VARCHAR NOT NULL,
     source VARCHAR NOT NULL
 );
 

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -1,7 +1,7 @@
 -- Your SQL goes here
 
 CREATE TABLE IF NOT EXISTS reverse_lookup (
-    lookup_id BYTEA NOT NULL PRIMARY KEY,
+    lookup_id VARCHAR NOT NULL PRIMARY KEY,
     secondary_key VARCHAR NOT NULL,
     partition_key VARCHAR NOT NULL,
     source VARCHAR NOT NULL,

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -1,10 +1,10 @@
 -- Your SQL goes here
 
 CREATE TABLE IF NOT EXISTS reverse_lookup (
-    lookup_id VARCHAR(255) NOT NULL PRIMARY KEY,
-    sk_id VARCHAR(50) NOT NULL,
-    pk_id VARCHAR(255) NOT NULL,
-    source VARCHAR(30) NOT NULL
+    lookup_id BYTEA NOT NULL PRIMARY KEY,
+    sk_id VARCHAR NOT NULL,
+    pk_id VARCHAR NOT NULL,
+    source VARCHAR NOT NULL
 );
 
 CREATE INDEX IF NOT EXISTS lookup_id_index ON reverse_lookup (lookup_id);

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -1,0 +1,10 @@
+-- Your SQL goes here
+
+CREATE TABLE IF NOT EXISTS reverse_lookup (
+    lookup_id VARCHAR(255) NOT NULL PRIMARY KEY,
+    sk_id VARCHAR(50) NOT NULL,
+    pk_id VARCHAR(255) NOT NULL,
+    source VARCHAR(30) NOT NULL
+);
+
+CREATE INDEX IF NOT EXISTS lookup_id_index ON reverse_lookup (lookup_id);

--- a/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
+++ b/migrations/2026-06-24-125858_create_reverse_lookup_table/up.sql
@@ -7,5 +7,3 @@ CREATE TABLE IF NOT EXISTS reverse_lookup (
     source VARCHAR NOT NULL,
     update_by VARCHAR NOT NULL
 );
-
-CREATE INDEX IF NOT EXISTS lookup_id_index ON reverse_lookup (lookup_id);

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -90,6 +90,20 @@ pub enum EntityDBError {
     NotFoundError,
 }
 
+#[derive(Debug, Copy, Clone, thiserror::Error)]
+pub enum ReverseLookupDBError {
+    #[error("Error while connecting to database")]
+    DBError,
+    #[error("Error while finding reverse lookup record in the database")]
+    DBFilterError,
+    #[error("Error while inserting reverse lookup record in the database")]
+    DBInsertError,
+    #[error("Reverse lookup record not found in database")]
+    NotFoundError,
+    #[error("Unpredictable error occurred")]
+    UnknownError,
+}
+
 pub trait NotFoundError {
     fn is_not_found(&self) -> bool;
 }
@@ -103,5 +117,14 @@ impl NotFoundError for super::ContainerError<MerchantDBError> {
 impl NotFoundError for super::ContainerError<EntityDBError> {
     fn is_not_found(&self) -> bool {
         matches!(self.error.current_context(), EntityDBError::NotFoundError)
+    }
+}
+
+impl NotFoundError for super::ContainerError<ReverseLookupDBError> {
+    fn is_not_found(&self) -> bool {
+        matches!(
+            self.error.current_context(),
+            ReverseLookupDBError::NotFoundError
+        )
     }
 }

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -304,9 +304,9 @@ error_transform!(super::StorageError => super::ReverseLookupDBError);
 impl<'a> From<&'a super::StorageError> for super::ReverseLookupDBError {
     fn from(value: &'a super::StorageError) -> Self {
         match value {
-            super::StorageError::DBPoolError | super::StorageError::PoolClientFailure => {
-                Self::DBError
-            }
+            super::StorageError::DBPoolError
+            | super::StorageError::PoolClientFailure
+            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::NotFoundError => Self::NotFoundError,
             super::StorageError::DecryptionError

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -293,6 +293,40 @@ impl<'a> From<&'a super::EntityDBError> for super::ApiError {
     }
 }
 
+error_transform!(super::StorageError => super::ReverseLookupDBError);
+impl<'a> From<&'a super::StorageError> for super::ReverseLookupDBError {
+    fn from(value: &'a super::StorageError) -> Self {
+        match value {
+            super::StorageError::DBPoolError | super::StorageError::PoolClientFailure => {
+                Self::DBError
+            }
+            super::StorageError::FindError => Self::DBFilterError,
+            super::StorageError::NotFoundError => Self::NotFoundError,
+            super::StorageError::DecryptionError
+            | super::StorageError::EncryptionError
+            | super::StorageError::DeleteError => Self::UnknownError,
+            super::StorageError::InsertError | super::StorageError::UpdateError => {
+                Self::DBInsertError
+            }
+        }
+    }
+}
+
+error_transform!(super::ReverseLookupDBError => super::ApiError);
+impl<'a> From<&'a super::ReverseLookupDBError> for super::ApiError {
+    fn from(value: &'a super::ReverseLookupDBError) -> Self {
+        match value {
+            super::ReverseLookupDBError::DBError => Self::DatabaseError,
+            super::ReverseLookupDBError::DBFilterError => Self::RetrieveDataFailed("reverse lookup"),
+            super::ReverseLookupDBError::DBInsertError => {
+                Self::DatabaseInsertFailed("reverse lookup")
+            }
+            super::ReverseLookupDBError::NotFoundError => Self::NotFoundError,
+            super::ReverseLookupDBError::UnknownError => Self::UnknownError,
+        }
+    }
+}
+
 error_transform!(super::KeyManagerError => super::ApiError);
 impl<'a> From<&'a super::KeyManagerError> for super::ApiError {
     fn from(value: &'a super::KeyManagerError) -> Self {

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -317,7 +317,9 @@ impl<'a> From<&'a super::ReverseLookupDBError> for super::ApiError {
     fn from(value: &'a super::ReverseLookupDBError) -> Self {
         match value {
             super::ReverseLookupDBError::DBError => Self::DatabaseError,
-            super::ReverseLookupDBError::DBFilterError => Self::RetrieveDataFailed("reverse lookup"),
+            super::ReverseLookupDBError::DBFilterError => {
+                Self::RetrieveDataFailed("reverse lookup")
+            }
             super::ReverseLookupDBError::DBInsertError => {
                 Self::DatabaseInsertFailed("reverse lookup")
             }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -324,8 +324,8 @@ pub(crate) trait FingerprintInterface {
 /// ReverseLookupInterface:
 ///
 /// Interface for interacting with the reverse_lookup database table.
-/// The table maps an external lookup_id to the primary key (pk_id) and
-/// secondary key (sk_id) along with the source of insertion.
+/// The table maps an external lookup_id to the partition key and
+/// secondary key along with the source of insertion.
 pub(crate) trait ReverseLookupInterface {
     type Error;
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -319,7 +319,7 @@ pub(crate) trait FingerprintInterface {
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>>;
 }
 
-#[allow(dead_code)]
+#[expect(dead_code)]
 ///
 /// ReverseLookupInterface:
 ///

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -332,7 +332,7 @@ pub(crate) trait ReverseLookupInterface {
     /// Fetch a reverse lookup record by its lookup_id.
     async fn find_by_lookup_id(
         &self,
-        lookup_id: &str,
+        lookup_id: &[u8],
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>>;
 
     /// Insert a new reverse lookup record into the database.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -332,7 +332,7 @@ pub(crate) trait ReverseLookupInterface {
     /// Fetch a reverse lookup record by its lookup_id.
     async fn find_by_lookup_id(
         &self,
-        lookup_id: &[u8],
+        lookup_id: &str,
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>>;
 
     /// Insert a new reverse lookup record into the database.

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -236,6 +236,29 @@ pub(crate) trait FingerprintInterface {
     ) -> Result<types::Fingerprint, ContainerError<Self::Error>>;
 }
 
+#[allow(dead_code)]
+///
+/// ReverseLookupInterface:
+///
+/// Interface for interacting with the reverse_lookup database table.
+/// The table maps an external lookup_id to the primary key (pk_id) and
+/// secondary key (sk_id) along with the source of insertion.
+pub(crate) trait ReverseLookupInterface {
+    type Error;
+
+    /// Fetch a reverse lookup record by its lookup_id.
+    async fn find_by_lookup_id(
+        &self,
+        lookup_id: &str,
+    ) -> Result<types::ReverseLookup, ContainerError<Self::Error>>;
+
+    /// Insert a new reverse lookup record into the database.
+    async fn insert_reverse_lookup(
+        &self,
+        new: types::ReverseLookupNew,
+    ) -> Result<types::ReverseLookup, ContainerError<Self::Error>>;
+}
+
 ///
 /// EntityInterface:
 ///

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -337,7 +337,7 @@ impl super::ReverseLookupInterface for Storage {
 
     async fn find_by_lookup_id(
         &self,
-        lookup_id: &str,
+        lookup_id: &[u8],
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
         let mut conn = self.get_conn().await?;
 

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -337,7 +337,7 @@ impl super::ReverseLookupInterface for Storage {
 
     async fn find_by_lookup_id(
         &self,
-        lookup_id: &[u8],
+        lookup_id: &str,
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
         let mut conn = self.get_conn().await?;
 

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -444,3 +444,45 @@ impl super::EntityInterface for Storage {
             .map_err(From::from)
     }
 }
+
+impl super::ReverseLookupInterface for Storage {
+    type Error = error::ReverseLookupDBError;
+
+    async fn find_by_lookup_id(
+        &self,
+        lookup_id: &str,
+    ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
+        let mut conn = self.get_conn().await?;
+
+        let output: Result<types::ReverseLookup, diesel::result::Error> =
+            types::ReverseLookup::table()
+                .filter(schema::reverse_lookup::lookup_id.eq(lookup_id))
+                .get_result(&mut conn)
+                .await;
+
+        match output {
+            Err(err) => match err {
+                diesel::result::Error::NotFound => {
+                    Err(err).change_error(error::StorageError::NotFoundError)
+                }
+                _ => Err(err).change_error(error::StorageError::FindError),
+            },
+            Ok(reverse_lookup) => Ok(reverse_lookup),
+        }
+        .map_err(From::from)
+    }
+
+    async fn insert_reverse_lookup(
+        &self,
+        new: types::ReverseLookupNew,
+    ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
+        let mut conn = self.get_conn().await?;
+
+        diesel::insert_into(types::ReverseLookup::table())
+            .values(new)
+            .get_result(&mut conn)
+            .await
+            .change_error(error::StorageError::InsertError)
+            .map_err(From::from)
+    }
+}

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -60,8 +60,8 @@ diesel::table! {
 diesel::table! {
     reverse_lookup (lookup_id) {
         lookup_id -> Bytea,
-        sk_id -> Varchar,
-        pk_id -> Varchar,
+        secondary_key -> Varchar,
+        partition_key -> Varchar,
         source -> Varchar,
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -59,13 +59,9 @@ diesel::table! {
 
 diesel::table! {
     reverse_lookup (lookup_id) {
-        #[max_length = 255]
-        lookup_id -> Varchar,
-        #[max_length = 50]
+        lookup_id -> Bytea,
         sk_id -> Varchar,
-        #[max_length = 255]
         pk_id -> Varchar,
-        #[max_length = 30]
         source -> Varchar,
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -59,7 +59,7 @@ diesel::table! {
 
 diesel::table! {
     reverse_lookup (lookup_id) {
-        lookup_id -> Bytea,
+        lookup_id -> Varchar,
         secondary_key -> Varchar,
         partition_key -> Varchar,
         source -> Varchar,

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -63,6 +63,7 @@ diesel::table! {
         secondary_key -> Varchar,
         partition_key -> Varchar,
         source -> Varchar,
+        update_by -> Varchar,
     }
 }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -58,6 +58,19 @@ diesel::table! {
 }
 
 diesel::table! {
+    reverse_lookup (lookup_id) {
+        #[max_length = 255]
+        lookup_id -> Varchar,
+        #[max_length = 50]
+        sk_id -> Varchar,
+        #[max_length = 255]
+        pk_id -> Varchar,
+        #[max_length = 30]
+        source -> Varchar,
+    }
+}
+
+diesel::table! {
     vault (entity_id, vault_id) {
         id -> Int4,
         #[max_length = 255]
@@ -76,5 +89,6 @@ diesel::allow_tables_to_appear_in_same_query!(
     hash_table,
     locker,
     merchant,
+    reverse_lookup,
     vault,
 );

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -142,7 +142,7 @@ impl<'a> LockerNew<'a> {
 
 #[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = schema::reverse_lookup, primary_key(lookup_id))]
-#[allow(dead_code)]
+#[expect(dead_code)]
 pub(crate) struct ReverseLookup {
     pub lookup_id: Vec<u8>,
     pub secondary_key: String,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -141,6 +141,36 @@ impl<'a> LockerNew<'a> {
 }
 
 #[derive(Debug, Clone, Identifiable, Queryable)]
+#[diesel(table_name = schema::reverse_lookup, primary_key(lookup_id))]
+#[allow(dead_code)]
+pub(crate) struct ReverseLookup {
+    pub lookup_id: String,
+    pub sk_id: String,
+    pub pk_id: String,
+    pub source: String,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = schema::reverse_lookup)]
+pub(crate) struct ReverseLookupNew {
+    pub lookup_id: String,
+    pub sk_id: String,
+    pub pk_id: String,
+    pub source: String,
+}
+
+impl From<ReverseLookupNew> for ReverseLookup {
+    fn from(value: ReverseLookupNew) -> Self {
+        Self {
+            lookup_id: value.lookup_id,
+            sk_id: value.sk_id,
+            pk_id: value.pk_id,
+            source: value.source,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable)]
 #[diesel(table_name = schema::hash_table)]
 pub struct HashTable {
     pub id: i32,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -145,8 +145,8 @@ impl<'a> LockerNew<'a> {
 #[allow(dead_code)]
 pub(crate) struct ReverseLookup {
     pub lookup_id: Vec<u8>,
-    pub sk_id: String,
-    pub pk_id: String,
+    pub secondary_key: String,
+    pub partition_key: String,
     pub source: String,
 }
 
@@ -154,8 +154,8 @@ pub(crate) struct ReverseLookup {
 #[diesel(table_name = schema::reverse_lookup)]
 pub(crate) struct ReverseLookupNew {
     pub lookup_id: Vec<u8>,
-    pub sk_id: String,
-    pub pk_id: String,
+    pub secondary_key: String,
+    pub partition_key: String,
     pub source: String,
 }
 
@@ -163,8 +163,8 @@ impl From<ReverseLookupNew> for ReverseLookup {
     fn from(value: ReverseLookupNew) -> Self {
         Self {
             lookup_id: value.lookup_id,
-            sk_id: value.sk_id,
-            pk_id: value.pk_id,
+            secondary_key: value.secondary_key,
+            partition_key: value.partition_key,
             source: value.source,
         }
     }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -144,7 +144,7 @@ impl<'a> LockerNew<'a> {
 #[diesel(table_name = schema::reverse_lookup, primary_key(lookup_id))]
 #[allow(dead_code)]
 pub(crate) struct ReverseLookup {
-    pub lookup_id: String,
+    pub lookup_id: Vec<u8>,
     pub sk_id: String,
     pub pk_id: String,
     pub source: String,
@@ -153,7 +153,7 @@ pub(crate) struct ReverseLookup {
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = schema::reverse_lookup)]
 pub(crate) struct ReverseLookupNew {
-    pub lookup_id: String,
+    pub lookup_id: Vec<u8>,
     pub sk_id: String,
     pub pk_id: String,
     pub source: String,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -144,7 +144,7 @@ impl<'a> LockerNew<'a> {
 #[diesel(table_name = schema::reverse_lookup, primary_key(lookup_id))]
 #[expect(dead_code)]
 pub(crate) struct ReverseLookup {
-    pub lookup_id: Vec<u8>,
+    pub lookup_id: String,
     pub secondary_key: String,
     pub partition_key: String,
     pub source: String,
@@ -154,7 +154,7 @@ pub(crate) struct ReverseLookup {
 #[derive(Debug, Clone, Insertable)]
 #[diesel(table_name = schema::reverse_lookup)]
 pub(crate) struct ReverseLookupNew {
-    pub lookup_id: Vec<u8>,
+    pub lookup_id: String,
     pub secondary_key: String,
     pub partition_key: String,
     pub source: String,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -148,6 +148,7 @@ pub(crate) struct ReverseLookup {
     pub secondary_key: String,
     pub partition_key: String,
     pub source: String,
+    pub update_by: String,
 }
 
 #[derive(Debug, Clone, Insertable)]
@@ -157,6 +158,7 @@ pub(crate) struct ReverseLookupNew {
     pub secondary_key: String,
     pub partition_key: String,
     pub source: String,
+    pub update_by: String,
 }
 
 impl From<ReverseLookupNew> for ReverseLookup {
@@ -166,6 +168,7 @@ impl From<ReverseLookupNew> for ReverseLookup {
             secondary_key: value.secondary_key,
             partition_key: value.partition_key,
             source: value.source,
+            update_by: value.update_by,
         }
     }
 }


### PR DESCRIPTION
## Summary
This PR introduces the `reverse_lookup` table to the locker, following the existing Diesel + migration patterns and aligning with the reference implementation in the main Hyperswitch repo.

## Changes
- Added a new Diesel migration to create the `reverse_lookup` table.
- Updated `src/storage/schema.rs` with the new table definition.
- Added `ReverseLookup` and `ReverseLookupNew` types in `src/storage/types.rs`.
- Introduced `ReverseLookupInterface` in `src/storage.rs`.
- Implemented the interface for `Storage` in `src/storage/db.rs`.
- Added `ReverseLookupDBError` and the corresponding error transforms.

## Verification
- `cargo check` passes
- `cargo check --all-features` passes
