### PR TITLE
refactor: change hash_table primary key to data_hash

### DIFF
--- a/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/down.sql
+++ b/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hash_table_hash_id_key_idx;

--- a/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/metadata.toml
+++ b/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/metadata.toml
@@ -1,2 +1,2 @@
-# Needed because postresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
+# Needed because postgresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
 run_in_transaction = false

--- a/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/metadata.toml
+++ b/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/metadata.toml
@@ -1,0 +1,2 @@
+# Needed because postresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
+run_in_transaction = false

--- a/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/up.sql
+++ b/migrations/2026-06-30-000000_hash-table-hash-id-unique-index/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS hash_table_hash_id_key_idx
+ON hash_table (hash_id);

--- a/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/down.sql
+++ b/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/down.sql
@@ -1,0 +1,1 @@
+DROP INDEX CONCURRENTLY IF EXISTS hash_table_data_hash_pkey_idx;

--- a/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/metadata.toml
+++ b/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/metadata.toml
@@ -1,2 +1,2 @@
-# Needed because postresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
+# Needed because postgresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
 run_in_transaction = false

--- a/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/metadata.toml
+++ b/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/metadata.toml
@@ -1,0 +1,2 @@
+# Needed because postresql does not allow 'DROP/CREATE INDEX CONCURRENTLY' inside a transaction block
+run_in_transaction = false

--- a/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/up.sql
+++ b/migrations/2026-06-30-000001_hash-table-data-hash-primary-index/up.sql
@@ -1,0 +1,2 @@
+CREATE UNIQUE INDEX CONCURRENTLY IF NOT EXISTS hash_table_data_hash_pkey_idx
+ON hash_table (data_hash);

--- a/migrations/2026-06-30-000002_hash-table-primary-key-swap/down.sql
+++ b/migrations/2026-06-30-000002_hash-table-primary-key-swap/down.sql
@@ -9,6 +9,7 @@ ALTER TABLE hash_table
     ADD CONSTRAINT hash_table_data_hash_key
         UNIQUE (data_hash);
 
+-- In production environments with live traffic, run these index creations with CONCURRENTLY.
 CREATE UNIQUE INDEX IF NOT EXISTS hash_table_hash_id_key_idx
 ON hash_table (hash_id);
 

--- a/migrations/2026-06-30-000002_hash-table-primary-key-swap/down.sql
+++ b/migrations/2026-06-30-000002_hash-table-primary-key-swap/down.sql
@@ -1,0 +1,16 @@
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '5s';
+
+ALTER TABLE hash_table
+    DROP CONSTRAINT hash_table_pkey,
+    DROP CONSTRAINT hash_table_hash_id_key,
+    ADD CONSTRAINT hash_table_pkey
+        PRIMARY KEY (hash_id),
+    ADD CONSTRAINT hash_table_data_hash_key
+        UNIQUE (data_hash);
+
+CREATE UNIQUE INDEX IF NOT EXISTS hash_table_hash_id_key_idx
+ON hash_table (hash_id);
+
+CREATE UNIQUE INDEX IF NOT EXISTS hash_table_data_hash_pkey_idx
+ON hash_table (data_hash);

--- a/migrations/2026-06-30-000002_hash-table-primary-key-swap/up.sql
+++ b/migrations/2026-06-30-000002_hash-table-primary-key-swap/up.sql
@@ -1,0 +1,10 @@
+SET LOCAL lock_timeout = '2s';
+SET LOCAL statement_timeout = '5s';
+
+ALTER TABLE hash_table
+    DROP CONSTRAINT hash_table_pkey,
+    DROP CONSTRAINT hash_table_data_hash_key,
+    ADD CONSTRAINT hash_table_pkey
+        PRIMARY KEY USING INDEX hash_table_data_hash_pkey_idx,
+    ADD CONSTRAINT hash_table_hash_id_key
+        UNIQUE USING INDEX hash_table_hash_id_key_idx;

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -21,7 +21,7 @@ diesel::table! {
 }
 
 diesel::table! {
-    hash_table (hash_id) {
+    hash_table (data_hash) {
         id -> Int4,
         #[max_length = 255]
         hash_id -> Varchar,


### PR DESCRIPTION
## Summary
- add Diesel migrations to create replacement unique indexes and swap hash_table primary key from hash_id to data_hash
- keep hash_id protected with a unique constraint after the swap
- update Diesel schema to use data_hash as the hash_table primary key

## Verification
- diesel migration run
- diesel migration redo
<img width="1019" height="269" alt="image" src="https://github.com/user-attachments/assets/cd70be49-beaf-486c-b3d8-90c9ce796283" />

