### PR TITLE
chore(runtime): add support for optional static headers in runtime config requests

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -140,3 +140,7 @@ metrics_export_interval_secs = 60  # How often to export metrics (seconds)
 # base_url = "http://localhost:8080/configs"
 # api_key = ""
 
+# Optional static headers sent on every runtime config pull request (omit entirely to send none)
+# [runtime_config.endpoint.headers]
+# accept = "application/json"
+

--- a/src/config.rs
+++ b/src/config.rs
@@ -401,6 +401,8 @@ impl std::fmt::Display for Env {
 pub struct RuntimeConfigEndpoint {
     pub base_url: String,
     pub api_key: hyperswitch_masking::Secret<String>,
+    #[serde(default)]
+    pub headers: std::collections::HashMap<String, hyperswitch_masking::Secret<String>>,
 }
 
 /// Runtime configuration source.

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,4 +1,4 @@
-use std::time::Duration;
+use std::{collections::HashMap, time::Duration};
 
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
@@ -37,6 +37,25 @@ pub struct RuntimeConfigManager {
 }
 
 impl RuntimeConfigManager {
+    fn build_header_map(
+        headers: &HashMap<String, Secret<String>>,
+    ) -> error_stack::Result<reqwest::header::HeaderMap, error::ConfigurationError> {
+        let mut map = reqwest::header::HeaderMap::new();
+        for (name, value) in headers {
+            let hname = reqwest::header::HeaderName::from_bytes(name.as_bytes())
+                .change_context(error::ConfigurationError::InvalidConfigurationValueError(format!(
+                    "invalid runtime_config header name `{name}`"
+                )))?;
+            let mut hval = reqwest::header::HeaderValue::from_str(value.peek())
+                .change_context(error::ConfigurationError::InvalidConfigurationValueError(format!(
+                    "invalid runtime_config header value for `{name}`"
+                )))?;
+            hval.set_sensitive(true);
+            map.insert(hname, hval);
+        }
+        Ok(map)
+    }
+
     /// Construct a new runtime config manager.
     pub fn new(
         config: &RuntimeConfig,
@@ -57,6 +76,7 @@ impl RuntimeConfigManager {
                     .redirect(reqwest::redirect::Policy::none())
                     .pool_idle_timeout(Duration::from_secs(client_idle_timeout))
                     .pool_max_idle_per_host(pool_max_idle_per_host)
+                    .default_headers(Self::build_header_map(&endpoint.headers)?)
                     .build()
                     .change_context(error::ConfigurationError::InvalidConfigurationValueError(
                         "Failed to build HTTP client for runtime config endpoint".into(),

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -40,22 +40,21 @@ impl RuntimeConfigManager {
     fn build_header_map(
         headers: &HashMap<String, Secret<String>>,
     ) -> error_stack::Result<reqwest::header::HeaderMap, error::ConfigurationError> {
-        let mut map = reqwest::header::HeaderMap::new();
-        for (name, value) in headers {
-            let hname = reqwest::header::HeaderName::from_bytes(name.as_bytes()).change_context(
-                error::ConfigurationError::InvalidConfigurationValueError(format!(
-                    "invalid runtime_config header name `{name}`"
-                )),
-            )?;
-            let mut hval = reqwest::header::HeaderValue::from_str(value.peek()).change_context(
-                error::ConfigurationError::InvalidConfigurationValueError(format!(
-                    "invalid runtime_config header value for `{name}`"
-                )),
-            )?;
-            hval.set_sensitive(true);
-            map.insert(hname, hval);
-        }
-        Ok(map)
+        headers
+            .iter()
+            .map(|(name, value)| {
+                let header_name = reqwest::header::HeaderName::from_bytes(name.as_bytes())
+                    .change_context(error::ConfigurationError::InvalidConfigurationValueError(
+                        format!("invalid runtime_config header name `{name}`"),
+                    ))?;
+                let mut header_value = reqwest::header::HeaderValue::from_str(value.peek())
+                    .change_context(error::ConfigurationError::InvalidConfigurationValueError(
+                        format!("invalid runtime_config header value for `{name}`"),
+                    ))?;
+                header_value.set_sensitive(true);
+                Ok((header_name, header_value))
+            })
+            .collect()
     }
 
     /// Construct a new runtime config manager.

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -42,14 +42,16 @@ impl RuntimeConfigManager {
     ) -> error_stack::Result<reqwest::header::HeaderMap, error::ConfigurationError> {
         let mut map = reqwest::header::HeaderMap::new();
         for (name, value) in headers {
-            let hname = reqwest::header::HeaderName::from_bytes(name.as_bytes())
-                .change_context(error::ConfigurationError::InvalidConfigurationValueError(format!(
+            let hname = reqwest::header::HeaderName::from_bytes(name.as_bytes()).change_context(
+                error::ConfigurationError::InvalidConfigurationValueError(format!(
                     "invalid runtime_config header name `{name}`"
-                )))?;
-            let mut hval = reqwest::header::HeaderValue::from_str(value.peek())
-                .change_context(error::ConfigurationError::InvalidConfigurationValueError(format!(
+                )),
+            )?;
+            let mut hval = reqwest::header::HeaderValue::from_str(value.peek()).change_context(
+                error::ConfigurationError::InvalidConfigurationValueError(format!(
                     "invalid runtime_config header value for `{name}`"
-                )))?;
+                )),
+            )?;
             hval.set_sensitive(true);
             map.insert(hname, hval);
         }


### PR DESCRIPTION
## Summary

Operators can now attach extra static headers (e.g. `accept`) to every runtime config pull request via `[runtime_config.endpoint.headers]` in TOML. No-op when unconfigured.

## Behavior

- Headers omitted → empty map → `default_headers` is no-op → byte-identical to today
- Headers present → baked into the client once at startup, sent on every pull