### PR TITLE
fix(security): mask tenant vault master_key to prevent plaintext leak in logs

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -134,7 +134,7 @@ pub struct Secrets {
 #[derive(serde::Deserialize, Debug, Clone)]
 pub struct TenantSecrets {
     #[serde(deserialize_with = "deserialize_hex")]
-    pub master_key: Vec<u8>,
+    pub master_key: hyperswitch_masking::Secret<Vec<u8>>,
     #[cfg(feature = "middleware")]
     pub public_key: hyperswitch_masking::Secret<String>,
 
@@ -147,7 +147,9 @@ pub struct TenantSecrets {
     pub redis_key_prefix: String,
 }
 
-fn deserialize_hex<'de, D>(deserializer: D) -> Result<Vec<u8>, D::Error>
+fn deserialize_hex<'de, D>(
+    deserializer: D,
+) -> Result<hyperswitch_masking::Secret<Vec<u8>>, D::Error>
 where
     D: serde::Deserializer<'de>,
 {
@@ -155,7 +157,7 @@ where
 
     let deserialized_str = deserialized_str.into_bytes();
 
-    Ok(deserialized_str)
+    Ok(hyperswitch_masking::Secret::new(deserialized_str))
 }
 
 #[derive(serde::Deserialize, Debug, Clone)]
@@ -293,7 +295,7 @@ impl GlobalConfig {
             tenant_secrets.master_key = hex::decode(
                 secret_management_client
                     .get_secret(
-                        String::from_utf8(tenant_secrets.master_key.clone())
+                        String::from_utf8(tenant_secrets.master_key.clone().expose())
                             .expect("Failed while converting master key to `String`")
                             .into(),
                     )
@@ -302,6 +304,7 @@ impl GlobalConfig {
                     .expose(),
             )
             .expect("Failed to hex decode master key")
+            .into()
         }
 
         #[cfg(feature = "middleware")]

--- a/src/crypto/keymanager/external_keymanager/utils.rs
+++ b/src/crypto/keymanager/external_keymanager/utils.rs
@@ -2,7 +2,7 @@ use std::collections::HashSet;
 
 use base64::Engine;
 use hyper::header::{AUTHORIZATION, CONTENT_TYPE};
-use hyperswitch_masking::{Mask, Maskable};
+use hyperswitch_masking::{Mask, Maskable, PeekInterface};
 
 use crate::{app::TenantAppState, crypto::consts::BASE64_ENGINE, storage::consts::X_TENANT_ID};
 
@@ -10,7 +10,7 @@ pub fn get_key_manager_header(
     tenant_app_state: &TenantAppState,
 ) -> HashSet<(String, Maskable<String>)> {
     let broken_master_key = {
-        let broken_master_key = &tenant_app_state.config.tenant_secrets.master_key;
+        let broken_master_key = tenant_app_state.config.tenant_secrets.master_key.peek();
         let (left_half, right_half) = broken_master_key.split_at(broken_master_key.len() / 2);
         let hex_left = hex::encode(left_half);
         let hex_right = hex::encode(right_half);

--- a/src/crypto/keymanager/internal_keymanager.rs
+++ b/src/crypto/keymanager/internal_keymanager.rs
@@ -20,8 +20,14 @@ impl super::KeyProvider for InternalKeyManager {
         tenant_app_state: &TenantAppState,
         entity_id: String,
     ) -> Result<Box<dyn CryptoOperationsManager>, ContainerError<error::ApiError>> {
-        let master_encryption =
-            GcmAes256::new(tenant_app_state.config.tenant_secrets.master_key.clone());
+        let master_encryption = GcmAes256::new(
+            tenant_app_state
+                .config
+                .tenant_secrets
+                .master_key
+                .clone()
+                .expose(),
+        );
 
         let merchant = tenant_app_state
             .db
@@ -38,8 +44,14 @@ impl super::KeyProvider for InternalKeyManager {
         tenant_app_state: &TenantAppState,
         entity_id: String,
     ) -> Result<Box<dyn CryptoOperationsManager>, ContainerError<error::ApiError>> {
-        let master_encryption =
-            GcmAes256::new(tenant_app_state.config.tenant_secrets.master_key.clone());
+        let master_encryption = GcmAes256::new(
+            tenant_app_state
+                .config
+                .tenant_secrets
+                .master_key
+                .clone()
+                .expose(),
+        );
 
         let entity =
             merchant::find_or_create(tenant_app_state, &entity_id, &master_encryption).await;

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use axum::{Json, extract::State, routing::post};
 use error_stack::ResultExt;
+use hyperswitch_masking::{PeekInterface, Secret};
 
 use crate::{
     app::TenantAppState,
@@ -160,11 +161,11 @@ async fn aes_decrypt_custodian_key(
         hex::decode(custodian_key)
             .change_error(error::ApiError::DecryptingKeysFailed("Hex dcoding failed"))?,
     )
-    .decrypt(tenant_config.tenant_secrets.master_key.clone())
+    .decrypt(tenant_config.tenant_secrets.master_key.peek().clone())
     .change_error(error::ApiError::DecryptingKeysFailed(
         "AES decryption failed",
     ))?;
 
-    tenant_config.tenant_secrets.master_key = aes_decrypted_master_key;
+    tenant_config.tenant_secrets.master_key = Secret::new(aes_decrypted_master_key);
     Ok(())
 }

--- a/src/routes/key_migration.rs
+++ b/src/routes/key_migration.rs
@@ -37,8 +37,14 @@ pub async fn transfer_keys(
     TenantStateResolver(tenant_app_state): TenantStateResolver,
     Json(request): Json<MerchantKeyTransferRequest>,
 ) -> Result<Json<TransferKeyResponse>, ContainerError<error::ApiError>> {
-    let master_encryption =
-        GcmAes256::new(tenant_app_state.config.tenant_secrets.master_key.clone());
+    let master_encryption = GcmAes256::new(
+        tenant_app_state
+            .config
+            .tenant_secrets
+            .master_key
+            .clone()
+            .expose(),
+    );
     let merchant_keys = tenant_app_state
         .db
         .find_all_keys_excluding_entity_keys(&master_encryption, request.limit)


### PR DESCRIPTION
## Summary
- `TenantSecrets::master_key` was a plain `Vec<u8>` with no masking, unlike the adjacent `public_key`/`locker_private_key` fields which are wrapped in `Secret<String>`.
- After `fetch_raw_secrets()` KMS-decrypts it, the field holds the raw plaintext card-vault master key for the tenant. Any `Debug`-print of the config struct (e.g. startup/debug logging) dumped this key byte-by-byte in plaintext — confirmed via a real log sample showing the raw key array while `public_key` correctly showed `***`.
- Wraps `master_key` in `hyperswitch_masking::Secret<Vec<u8>>` so `Debug` output is redacted, and updates the handful of call sites (`internal_keymanager.rs`, `external_keymanager/utils.rs`, `key_custodian.rs`, `key_migration.rs`) to `.expose()`/`.peek()` as appropriate.

## Test plan
- [x] `cargo check --all-features --all-targets`
- [x] `cargo clippy --all-features --all-targets`
- [x] `cargo fmt`
- [x] `cargo test --all-features` (all 18 unit tests + doctests pass)
- [ ] Rotate the tenant master key(s) that were exposed in existing logs, once this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)