### PR TITLE
feat(kv): validate runtime storage transitions

### DIFF
--- a/src/app.rs
+++ b/src/app.rs
@@ -58,6 +58,7 @@ impl TenantAppState {
         api_client: ApiClient,
         #[cfg(feature = "redis")] shared_redis: Option<&storage::redis::RedisStore>,
         runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
+        #[cfg(feature = "kv")] kv_store: Arc<storage::KvGlobalStore>,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
         #[cfg(feature = "redis")]
         let tenant_redis = shared_redis
@@ -72,7 +73,7 @@ impl TenantAppState {
             #[cfg(feature = "kv")]
             tenant_redis.clone(),
             #[cfg(feature = "kv")]
-            &global_config.kv,
+            kv_store,
         )
         .await
         .map(
@@ -157,9 +158,14 @@ pub async fn server_builder(
     metrics_handle: observability::MetricsHandle,
 ) -> Result<(), error::ConfigurationError> {
     // Warm + periodically refresh the runtime-config cache. No-op when disabled.
-    let _prefetch_handle = global_app_state
-        .runtime_config_manager
-        .spawn_prefetch_task();
+    let runtime_config_manager = global_app_state.runtime_config_manager.clone();
+    let state_for_prefetch = global_app_state.clone();
+    let _prefetch_handle = runtime_config_manager.spawn_prefetch_task(move || {
+        let state_for_prefetch = state_for_prefetch.clone();
+        async move {
+            state_for_prefetch.apply_runtime_config_updates().await;
+        }
+    });
 
     let socket_addr = std::net::SocketAddr::new(
         global_app_state.global_config.server.host.parse()?,

--- a/src/app.rs
+++ b/src/app.rs
@@ -58,7 +58,7 @@ impl TenantAppState {
         api_client: ApiClient,
         #[cfg(feature = "redis")] shared_redis: Option<&storage::redis::RedisStore>,
         runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
-        #[cfg(feature = "kv")] kv_store: Arc<storage::KvGlobalStore>,
+        global_store: Arc<storage::GlobalStore>,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
         #[cfg(feature = "redis")]
         let tenant_redis = shared_redis
@@ -70,10 +70,9 @@ impl TenantAppState {
             global_config.read_replica.as_ref(),
             &tenant_config.tenant_secrets.schema,
             runtime_config_manager,
+            global_store,
             #[cfg(feature = "kv")]
             tenant_redis.clone(),
-            #[cfg(feature = "kv")]
-            kv_store,
         )
         .await
         .map(

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -32,6 +32,7 @@ pub fn serve() -> axum::Router<Arc<GlobalAppState>> {
     axum::Router::new()
         .route("/", get(health))
         .route("/diagnostics", get(diagnostics))
+        .route("/runtime-config", get(runtime_config_status))
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -46,6 +47,14 @@ pub async fn health() -> Json<HealthRespPayload> {
     Json(HealthRespPayload {
         message: "Health is good".into(),
     })
+}
+
+/// '/health/runtime-config` API handler`
+#[tracing::instrument(skip_all)]
+pub async fn runtime_config_status(
+    TenantStateResolver(state): TenantStateResolver,
+) -> Json<crate::storage::StorageRuntimeConfigStatus> {
+    Json(state.db.runtime_config_status().await)
 }
 
 #[derive(Debug, serde::Serialize, Default)]

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -125,6 +125,8 @@ pub async fn decrypt(
                 #[cfg(feature = "redis")]
                 global_app_state.redis_store.as_ref(),
                 global_app_state.runtime_config_manager.clone(),
+                #[cfg(feature = "kv")]
+                global_app_state.kv_store.clone(),
             )
             .await
             .change_context(error::ApiError::TenantError(

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -125,8 +125,7 @@ pub async fn decrypt(
                 #[cfg(feature = "redis")]
                 global_app_state.redis_store.as_ref(),
                 global_app_state.runtime_config_manager.clone(),
-                #[cfg(feature = "kv")]
-                global_app_state.kv_store.clone(),
+                global_app_state.storage_global_store.clone(),
             )
             .await
             .change_context(error::ApiError::TenantError(

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -29,6 +29,22 @@ enum RuntimeConfigState {
     },
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct RuntimeConfigStatus {
+    pub status: RuntimeConfigStatusKind,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub config: Option<serde_json::Value>,
+}
+
+#[derive(Debug, serde::Serialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RuntimeConfigStatusKind {
+    Disabled,
+    NotFetched,
+    Available,
+    Invalid,
+}
+
 /// Fetches the runtime-config endpoint on a schedule and serves the last-known-good body.
 pub struct RuntimeConfigManager {
     state: RuntimeConfigState,
@@ -114,6 +130,38 @@ impl RuntimeConfigManager {
             Err(error) => {
                 crate::logger::error!(?error, raw, "Failed to deserialize runtime config");
                 None
+            }
+        }
+    }
+
+    /// Returns the current cached runtime-config status without fetching from the endpoint.
+    pub async fn status(&self) -> RuntimeConfigStatus {
+        let RuntimeConfigState::Enabled { cache, .. } = &self.state else {
+            return RuntimeConfigStatus {
+                status: RuntimeConfigStatusKind::Disabled,
+                config: None,
+            };
+        };
+
+        let guard = cache.read().await;
+        let Some(raw) = guard.as_deref() else {
+            return RuntimeConfigStatus {
+                status: RuntimeConfigStatusKind::NotFetched,
+                config: None,
+            };
+        };
+
+        match serde_json::from_str(raw) {
+            Ok(config) => RuntimeConfigStatus {
+                status: RuntimeConfigStatusKind::Available,
+                config: Some(config),
+            },
+            Err(error) => {
+                crate::logger::error!(?error, raw, "Cached runtime config is invalid");
+                RuntimeConfigStatus {
+                    status: RuntimeConfigStatusKind::Invalid,
+                    config: None,
+                }
             }
         }
     }

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,4 +1,4 @@
-use std::{collections::HashMap, sync::Arc, time::Duration};
+use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
 
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
@@ -167,7 +167,14 @@ impl RuntimeConfigManager {
     }
 
     /// Spawn a background task that refreshes the config on an interval. Returns `None` when disabled.
-    pub fn spawn_prefetch_task(self: &Arc<Self>) -> Option<tokio::task::JoinHandle<()>> {
+    pub fn spawn_prefetch_task<F, Fut>(
+        self: &Arc<Self>,
+        on_successful_fetch: F,
+    ) -> Option<tokio::task::JoinHandle<()>>
+    where
+        F: Fn() -> Fut + Send + Sync + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
         let refresh_interval = match &self.state {
             RuntimeConfigState::Disabled => return None,
             RuntimeConfigState::Enabled {
@@ -183,21 +190,25 @@ impl RuntimeConfigManager {
 
         Some(tokio::spawn(
             async move {
-                manager.prefetch().await;
+                if manager.prefetch().await {
+                    on_successful_fetch().await;
+                }
 
                 let mut ticker = tokio::time::interval(refresh_interval);
                 ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
 
                 loop {
                     ticker.tick().await;
-                    manager.prefetch().await;
+                    if manager.prefetch().await {
+                        on_successful_fetch().await;
+                    }
                 }
             }
             .in_current_span(),
         ))
     }
 
-    async fn prefetch(&self) {
+    async fn prefetch(&self) -> bool {
         let RuntimeConfigState::Enabled {
             endpoint_url,
             endpoint_path,
@@ -207,19 +218,21 @@ impl RuntimeConfigManager {
             ..
         } = &self.state
         else {
-            return;
+            return false;
         };
 
         match Self::fetch_config(endpoint_url, endpoint_path, api_key, client).await {
             Ok(body) => {
                 crate::logger::info!(config = %body, "Runtime config fetched");
                 *cache.write().await = Some(body);
+                true
             }
             Err(e) => {
                 crate::logger::warn!(
                     error = ?e,
                     "Failed to prefetch runtime config, keeping last-known-good"
                 );
+                false
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,7 +12,10 @@ pub mod storage_v2;
 pub mod types;
 pub mod utils;
 
-use std::sync::Arc;
+use std::sync::{
+    Arc,
+    atomic::{AtomicBool, Ordering},
+};
 
 use diesel_async::{
     AsyncPgConnection,
@@ -52,6 +55,7 @@ pub struct Storage {
     primary_pg_pool: Arc<Pool<AsyncPgConnection>>,
     replica_pg_pool: Option<Arc<Pool<AsyncPgConnection>>>,
     runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
+    use_replica: Arc<AtomicBool>,
     #[cfg(feature = "kv")]
     redis: Option<redis_store::RedisStore>,
     #[cfg(feature = "kv")]
@@ -154,6 +158,7 @@ impl Storage {
             primary_pg_pool: pg_pool,
             replica_pg_pool: replica_pool,
             runtime_config_manager,
+            use_replica: Arc::new(AtomicBool::new(false)),
             #[cfg(feature = "kv")]
             redis,
             #[cfg(feature = "kv")]
@@ -198,17 +203,36 @@ impl Storage {
         self.replica_pg_pool.is_some()
     }
 
-    /// Returns `true` when both a replica pool exists and runtime config allows replica reads.
+    /// Returns `true` when runtime config allows replica reads. Replica availability is checked
+    /// only while enabling replica reads.
     async fn should_use_replica(&self) -> bool {
         if !self.has_replica() {
             crate::logger::debug!("No replica pool configured");
             return false;
         }
 
-        self.runtime_config_manager
+        let requested_use_replica = self
+            .runtime_config_manager
             .get::<RuntimeConfigValues>()
             .await
-            .is_some_and(|runtime_conf| runtime_conf.use_replica)
+            .is_some_and(|runtime_conf| runtime_conf.use_replica);
+
+        let current_use_replica = self.use_replica.load(Ordering::Acquire);
+        match (current_use_replica, requested_use_replica) {
+            (false, true) => {
+                if let Err(error) = self.get_replica_conn().await {
+                    crate::logger::warn!(?error, "Read replica unavailable");
+                } else {
+                    self.use_replica.store(true, Ordering::Release);
+                }
+            }
+            (true, false) => {
+                self.use_replica.store(false, Ordering::Release);
+            }
+            _ => {}
+        }
+
+        self.use_replica.load(Ordering::Acquire)
     }
 
     /// Returns a connection from the replica pool when the runtime config enables it,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -49,6 +49,19 @@ pub struct RuntimeConfigValues {
     use_replica: bool,
 }
 
+#[derive(Debug, serde::Serialize)]
+pub struct StorageRuntimeConfigStatus {
+    pub runtime_config: crate::runtime_config::RuntimeConfigStatus,
+    pub storage: StorageRuntimeConfigState,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct StorageRuntimeConfigState {
+    pub use_replica: bool,
+    #[cfg(feature = "kv")]
+    pub kv_state: String,
+}
+
 /// Storage State that is to be passed though the application
 #[derive(Clone)]
 pub struct Storage {
@@ -201,6 +214,17 @@ impl Storage {
     /// Returns `true` if a read replica pool was configured and initialized.
     pub fn has_replica(&self) -> bool {
         self.replica_pg_pool.is_some()
+    }
+
+    pub async fn runtime_config_status(&self) -> StorageRuntimeConfigStatus {
+        StorageRuntimeConfigStatus {
+            runtime_config: self.runtime_config_manager.status().await,
+            storage: StorageRuntimeConfigState {
+                use_replica: self.use_replica.load(Ordering::Acquire),
+                #[cfg(feature = "kv")]
+                kv_state: self.kv_state.read().await.to_string(),
+            },
+        }
     }
 
     /// Returns `true` when runtime config allows replica reads. Replica availability is checked

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -281,9 +281,9 @@ impl Storage {
             .map(|runtime_config_values| runtime_config_values.enable_kv)
             .unwrap_or(kv::KvState::Disabled);
 
-        let mut current_state = self.kv_state.write().await;
+        let current_state = *self.kv_state.read().await;
         let can_enable_kv = if matches!(
-            (*current_state, requested_state),
+            (current_state, requested_state),
             (kv::KvState::Disabled, kv::KvState::Enabled)
         ) {
             match &self.redis {
@@ -294,6 +294,7 @@ impl Storage {
             false
         };
 
+        let mut current_state = self.kv_state.write().await;
         let next_state = current_state.apply_transition(requested_state, can_enable_kv);
         if next_state != *current_state {
             crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -294,11 +294,11 @@ impl Storage {
             false
         };
 
-        let mut current_state = self.kv_state.write().await;
+        let current_state = self.kv_state.read().await;
         let next_state = current_state.apply_transition(requested_state, can_enable_kv);
         if next_state != *current_state {
             crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
-            *current_state = next_state;
+            *self.kv_state.write().await = next_state;
         } else if requested_state != *current_state {
             crate::logger::warn!(
                 current = %*current_state,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -70,7 +70,7 @@ pub struct GlobalStore {
     #[cfg(feature = "kv")]
     config: crate::config::KvConfig,
     #[cfg(feature = "kv")]
-    state: RwLock<kv::KvState>,
+    kv_state: RwLock<kv::KvState>,
 }
 
 impl GlobalStore {
@@ -80,7 +80,7 @@ impl GlobalStore {
             #[cfg(feature = "kv")]
             config,
             #[cfg(feature = "kv")]
-            state: RwLock::new(kv::KvState::Disabled),
+            kv_state: RwLock::new(kv::KvState::Disabled),
         }
     }
 
@@ -116,7 +116,10 @@ impl GlobalStore {
                 if replica_health_check().await {
                     self.enable_replica();
                 } else {
-                    crate::logger::warn!("Read replica unavailable");
+                    crate::logger::warn!(
+                        storage_runtime_config = "state_refresh",
+                        "Read replica unavailable"
+                    );
                 }
             }
             (true, false) => {
@@ -127,8 +130,8 @@ impl GlobalStore {
     }
 
     #[cfg(feature = "kv")]
-    async fn state(&self) -> kv::KvState {
-        *self.state.read().await
+    async fn kv_state(&self) -> kv::KvState {
+        *self.kv_state.read().await
     }
 
     /// Apply runtime-config KV state transitions after the runtime config cache is refreshed.
@@ -144,7 +147,7 @@ impl GlobalStore {
             .map(|runtime_config_values| runtime_config_values.enable_kv)
             .unwrap_or(kv::KvState::Disabled);
 
-        let current_state = self.state().await;
+        let current_state = self.kv_state().await;
         let can_enable_kv = if matches!(
             (current_state, requested_state),
             (kv::KvState::Disabled, kv::KvState::Enabled)
@@ -155,13 +158,17 @@ impl GlobalStore {
                     .await
                     .inspect_err(|err| {
                         crate::logger::error!(
+                            storage_runtime_config = "state_refresh",
                             "error while checking redis connection, Error message: {}",
                             err
                         );
                     })
                     .is_ok(),
                 None => {
-                    crate::logger::error!("Redis connection unavailable");
+                    crate::logger::error!(
+                        storage_runtime_config = "state_refresh",
+                        "Redis connection unavailable"
+                    );
                     false
                 }
             }
@@ -169,13 +176,19 @@ impl GlobalStore {
             false
         };
 
-        let mut current_state = self.state.write().await;
+        let mut current_state = self.kv_state.write().await;
         let next_state = current_state.apply_transition(requested_state, can_enable_kv);
         if next_state != *current_state {
-            crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
+            crate::logger::info!(
+                storage_runtime_config = "state_refresh",
+                from = %*current_state,
+                to = %next_state,
+                "KV mode transition accepted"
+            );
             *current_state = next_state;
         } else if requested_state != *current_state {
             crate::logger::warn!(
+                storage_runtime_config = "state_refresh",
                 current = %*current_state,
                 requested = %requested_state,
                 "KV mode transition ignored"
@@ -336,7 +349,7 @@ impl Storage {
             storage: StorageRuntimeConfigState {
                 use_replica: self.global_store.use_replica(),
                 #[cfg(feature = "kv")]
-                kv_state: self.global_store.state().await.to_string(),
+                kv_state: self.global_store.kv_state().await.to_string(),
             },
         }
     }
@@ -361,7 +374,7 @@ impl Storage {
     /// Return the current KV state cached by the runtime-config poller.
     #[cfg(feature = "kv")]
     pub(crate) async fn kv_settings(&self) -> kv::KvState {
-        self.global_store.state().await
+        self.global_store.kv_state().await
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -62,27 +62,45 @@ pub struct StorageRuntimeConfigState {
     pub kv_state: String,
 }
 
-#[cfg(feature = "kv")]
-pub struct KvGlobalStore {
+pub struct GlobalStore {
+    use_replica: AtomicBool,
+    #[cfg(feature = "kv")]
     config: crate::config::KvConfig,
+    #[cfg(feature = "kv")]
     state: RwLock<kv::KvState>,
 }
 
-#[cfg(feature = "kv")]
-impl KvGlobalStore {
-    pub fn new(config: crate::config::KvConfig) -> Self {
+impl GlobalStore {
+    pub fn new(#[cfg(feature = "kv")] config: crate::config::KvConfig) -> Self {
         Self {
+            use_replica: AtomicBool::new(false),
+            #[cfg(feature = "kv")]
             config,
+            #[cfg(feature = "kv")]
             state: RwLock::new(kv::KvState::Disabled),
         }
     }
 
+    fn use_replica(&self) -> bool {
+        self.use_replica.load(Ordering::Acquire)
+    }
+
+    fn enable_replica(&self) {
+        self.use_replica.store(true, Ordering::Release);
+    }
+
+    fn disable_replica(&self) {
+        self.use_replica.store(false, Ordering::Release);
+    }
+
+    #[cfg(feature = "kv")]
     async fn state(&self) -> kv::KvState {
         *self.state.read().await
     }
 
     /// Apply runtime-config KV state transitions after the runtime config cache is refreshed.
-    pub(crate) async fn refresh_from_runtime_config(
+    #[cfg(feature = "kv")]
+    pub(crate) async fn refresh_kv_state_from_runtime_config(
         &self,
         runtime_config_manager: &crate::runtime_config::RuntimeConfigManager,
         redis: Option<&redis_store::RedisStore>,
@@ -106,11 +124,11 @@ impl KvGlobalStore {
             false
         };
 
-        let current_state = self.state.read().await;
+        let mut current_state = self.state.write().await;
         let next_state = current_state.apply_transition(requested_state, can_enable_kv);
         if next_state != *current_state {
             crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
-            *self.state.write().await = next_state;
+            *current_state = next_state;
         } else if requested_state != *current_state {
             crate::logger::warn!(
                 current = %*current_state,
@@ -127,11 +145,9 @@ pub struct Storage {
     primary_pg_pool: Arc<Pool<AsyncPgConnection>>,
     replica_pg_pool: Option<Arc<Pool<AsyncPgConnection>>>,
     runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
-    use_replica: Arc<AtomicBool>,
+    global_store: Arc<GlobalStore>,
     #[cfg(feature = "kv")]
     redis: Option<redis_store::RedisStore>,
-    #[cfg(feature = "kv")]
-    kv_store: Arc<KvGlobalStore>,
 }
 
 type DeadPoolConnType = Object<AsyncPgConnection>;
@@ -209,8 +225,8 @@ impl Storage {
         replica_config: Option<&Database>,
         schema: &str,
         runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
+        global_store: Arc<GlobalStore>,
         #[cfg(feature = "kv")] redis: Option<redis_store::RedisStore>,
-        #[cfg(feature = "kv")] kv_store: Arc<KvGlobalStore>,
     ) -> error_stack::Result<Self, error::StorageError> {
         let pg_pool = Arc::new(Self::create_database_connection_pool(
             primary_config,
@@ -228,11 +244,9 @@ impl Storage {
             primary_pg_pool: pg_pool,
             replica_pg_pool: replica_pool,
             runtime_config_manager,
-            use_replica: Arc::new(AtomicBool::new(false)),
+            global_store,
             #[cfg(feature = "kv")]
             redis,
-            #[cfg(feature = "kv")]
-            kv_store,
         })
     }
 
@@ -275,19 +289,19 @@ impl Storage {
         StorageRuntimeConfigStatus {
             runtime_config: self.runtime_config_manager.status().await,
             storage: StorageRuntimeConfigState {
-                use_replica: self.use_replica.load(Ordering::Acquire),
+                use_replica: self.global_store.use_replica(),
                 #[cfg(feature = "kv")]
-                kv_state: self.kv_store.state().await.to_string(),
+                kv_state: self.global_store.state().await.to_string(),
             },
         }
     }
 
-    /// Returns `true` when runtime config allows replica reads. Replica availability is checked
-    /// only while enabling replica reads.
-    async fn should_use_replica(&self) -> bool {
+    /// Apply runtime-config replica read transitions after the runtime config cache is refreshed.
+    pub(crate) async fn refresh_replica_state_from_runtime_config(&self) {
         if !self.has_replica() {
             crate::logger::debug!("No replica pool configured");
-            return false;
+            self.global_store.disable_replica();
+            return;
         }
 
         let requested_use_replica = self
@@ -296,28 +310,31 @@ impl Storage {
             .await
             .is_some_and(|runtime_conf| runtime_conf.use_replica);
 
-        let current_use_replica = self.use_replica.load(Ordering::Acquire);
+        let current_use_replica = self.global_store.use_replica();
         match (current_use_replica, requested_use_replica) {
             (false, true) => {
                 if let Err(error) = self.get_replica_conn().await {
                     crate::logger::warn!(?error, "Read replica unavailable");
                 } else {
-                    self.use_replica.store(true, Ordering::Release);
+                    self.global_store.enable_replica();
                 }
             }
             (true, false) => {
-                self.use_replica.store(false, Ordering::Release);
+                self.global_store.disable_replica();
             }
             _ => {}
         }
+    }
 
-        self.use_replica.load(Ordering::Acquire)
+    /// Returns `true` when runtime config allows replica reads.
+    fn should_use_replica(&self) -> bool {
+        self.has_replica() && self.global_store.use_replica()
     }
 
     /// Returns a connection from the replica pool when the runtime config enables it,
     /// otherwise returns a primary pool connection.
     pub async fn route_conn(&self) -> Result<DbConnection, ContainerError<error::StorageError>> {
-        if self.should_use_replica().await {
+        if self.should_use_replica() {
             crate::logger::debug!("Routing to read replica");
             self.get_replica_conn().await
         } else {
@@ -329,7 +346,7 @@ impl Storage {
     /// Return the current KV state cached by the runtime-config poller.
     #[cfg(feature = "kv")]
     pub(crate) async fn kv_settings(&self) -> kv::KvState {
-        self.kv_store.state().await
+        self.global_store.state().await
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
@@ -408,15 +425,15 @@ impl kv::RedisConnInterface for Storage {
 #[cfg(feature = "kv")]
 impl kv::KvStoreContext for Storage {
     fn ttl_for_kv(&self) -> u32 {
-        self.kv_store.config.ttl_for_kv
+        self.global_store.config.ttl_for_kv
     }
 
     fn drainer_stream_name(&self, shard_key: &str) -> String {
-        self.kv_store.config.drainer_stream_name(shard_key)
+        self.global_store.config.drainer_stream_name(shard_key)
     }
 
     fn drainer_num_partitions(&self) -> u8 {
-        self.kv_store.config.drainer_num_partitions
+        self.global_store.config.drainer_num_partitions
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -150,8 +150,20 @@ impl GlobalStore {
             (kv::KvState::Disabled, kv::KvState::Enabled)
         ) {
             match redis {
-                Some(redis) => redis.test().await.is_ok(),
-                None => false,
+                Some(redis) => redis
+                    .test()
+                    .await
+                    .inspect_err(|err| {
+                        crate::logger::error!(
+                            "error while checking redis connection, Error message: {}",
+                            err
+                        );
+                    })
+                    .is_ok(),
+                None => {
+                    crate::logger::error!("Redis connection unavailable");
+                    false
+                }
             }
         } else {
             false

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -23,6 +23,8 @@ use diesel_async::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
+#[cfg(feature = "kv")]
+use tokio::sync::RwLock;
 
 pub use self::scheme::StorageScheme;
 #[cfg(feature = "kv")]
@@ -54,6 +56,8 @@ pub struct Storage {
     redis: Option<redis_store::RedisStore>,
     #[cfg(feature = "kv")]
     kv_config: crate::config::KvConfig,
+    #[cfg(feature = "kv")]
+    kv_state: Arc<RwLock<kv::KvState>>,
 }
 
 type DeadPoolConnType = Object<AsyncPgConnection>;
@@ -154,6 +158,8 @@ impl Storage {
             redis,
             #[cfg(feature = "kv")]
             kv_config: kv_config.clone(),
+            #[cfg(feature = "kv")]
+            kv_state: Arc::new(RwLock::new(kv::KvState::Disabled)),
         })
     }
 
@@ -220,11 +226,39 @@ impl Storage {
     /// Resolve `KvState` from runtime config; fail-closed to `Disabled` when absent.
     #[cfg(feature = "kv")]
     pub(crate) async fn kv_settings(&self) -> kv::KvState {
-        self.runtime_config_manager
+        let requested_state = self
+            .runtime_config_manager
             .get::<RuntimeConfigValues>()
             .await
             .map(|runtime_config_values| runtime_config_values.enable_kv)
-            .unwrap_or(kv::KvState::Disabled)
+            .unwrap_or(kv::KvState::Disabled);
+
+        let mut current_state = self.kv_state.write().await;
+        let can_enable_kv = if matches!(
+            (*current_state, requested_state),
+            (kv::KvState::Disabled, kv::KvState::Enabled)
+        ) {
+            match &self.redis {
+                Some(redis) => redis.test().await.is_ok(),
+                None => false,
+            }
+        } else {
+            false
+        };
+
+        let next_state = current_state.apply_transition(requested_state, can_enable_kv);
+        if next_state != *current_state {
+            crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
+            *current_state = next_state;
+        } else if requested_state != *current_state {
+            crate::logger::warn!(
+                current = %*current_state,
+                requested = %requested_state,
+                "KV mode transition ignored"
+            );
+        }
+
+        *current_state
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,9 +12,12 @@ pub mod storage_v2;
 pub mod types;
 pub mod utils;
 
-use std::sync::{
-    Arc,
-    atomic::{AtomicBool, Ordering},
+use std::{
+    future::Future,
+    sync::{
+        Arc,
+        atomic::{AtomicBool, Ordering},
+    },
 };
 
 use diesel_async::{
@@ -91,6 +94,36 @@ impl GlobalStore {
 
     fn disable_replica(&self) {
         self.use_replica.store(false, Ordering::Release);
+    }
+
+    /// Apply runtime-config replica read transitions after the runtime config cache is refreshed.
+    pub(crate) async fn refresh_replica_state_from_runtime_config<F, Fut>(
+        &self,
+        runtime_config_manager: &crate::runtime_config::RuntimeConfigManager,
+        replica_health_check: F,
+    ) where
+        F: FnOnce() -> Fut,
+        Fut: Future<Output = bool>,
+    {
+        let requested_use_replica = runtime_config_manager
+            .get::<RuntimeConfigValues>()
+            .await
+            .is_some_and(|runtime_conf| runtime_conf.use_replica);
+
+        let current_use_replica = self.use_replica();
+        match (current_use_replica, requested_use_replica) {
+            (false, true) => {
+                if replica_health_check().await {
+                    self.enable_replica();
+                } else {
+                    crate::logger::warn!("Read replica unavailable");
+                }
+            }
+            (true, false) => {
+                self.disable_replica();
+            }
+            _ => {}
+        }
     }
 
     #[cfg(feature = "kv")]
@@ -293,36 +326,6 @@ impl Storage {
                 #[cfg(feature = "kv")]
                 kv_state: self.global_store.state().await.to_string(),
             },
-        }
-    }
-
-    /// Apply runtime-config replica read transitions after the runtime config cache is refreshed.
-    pub(crate) async fn refresh_replica_state_from_runtime_config(&self) {
-        if !self.has_replica() {
-            crate::logger::debug!("No replica pool configured");
-            self.global_store.disable_replica();
-            return;
-        }
-
-        let requested_use_replica = self
-            .runtime_config_manager
-            .get::<RuntimeConfigValues>()
-            .await
-            .is_some_and(|runtime_conf| runtime_conf.use_replica);
-
-        let current_use_replica = self.global_store.use_replica();
-        match (current_use_replica, requested_use_replica) {
-            (false, true) => {
-                if let Err(error) = self.get_replica_conn().await {
-                    crate::logger::warn!(?error, "Read replica unavailable");
-                } else {
-                    self.global_store.enable_replica();
-                }
-            }
-            (true, false) => {
-                self.global_store.disable_replica();
-            }
-            _ => {}
         }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -106,11 +106,11 @@ impl KvGlobalStore {
             false
         };
 
-        let mut current_state = self.state.write().await;
+        let current_state = self.state.read().await;
         let next_state = current_state.apply_transition(requested_state, can_enable_kv);
         if next_state != *current_state {
             crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
-            *current_state = next_state;
+            *self.state.write().await = next_state;
         } else if requested_state != *current_state {
             crate::logger::warn!(
                 current = %*current_state,

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -62,6 +62,65 @@ pub struct StorageRuntimeConfigState {
     pub kv_state: String,
 }
 
+#[cfg(feature = "kv")]
+pub struct KvGlobalStore {
+    config: crate::config::KvConfig,
+    state: RwLock<kv::KvState>,
+}
+
+#[cfg(feature = "kv")]
+impl KvGlobalStore {
+    pub fn new(config: crate::config::KvConfig) -> Self {
+        Self {
+            config,
+            state: RwLock::new(kv::KvState::Disabled),
+        }
+    }
+
+    async fn state(&self) -> kv::KvState {
+        *self.state.read().await
+    }
+
+    /// Apply runtime-config KV state transitions after the runtime config cache is refreshed.
+    pub(crate) async fn refresh_from_runtime_config(
+        &self,
+        runtime_config_manager: &crate::runtime_config::RuntimeConfigManager,
+        redis: Option<&redis_store::RedisStore>,
+    ) {
+        let requested_state = runtime_config_manager
+            .get::<RuntimeConfigValues>()
+            .await
+            .map(|runtime_config_values| runtime_config_values.enable_kv)
+            .unwrap_or(kv::KvState::Disabled);
+
+        let current_state = self.state().await;
+        let can_enable_kv = if matches!(
+            (current_state, requested_state),
+            (kv::KvState::Disabled, kv::KvState::Enabled)
+        ) {
+            match redis {
+                Some(redis) => redis.test().await.is_ok(),
+                None => false,
+            }
+        } else {
+            false
+        };
+
+        let mut current_state = self.state.write().await;
+        let next_state = current_state.apply_transition(requested_state, can_enable_kv);
+        if next_state != *current_state {
+            crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
+            *current_state = next_state;
+        } else if requested_state != *current_state {
+            crate::logger::warn!(
+                current = %*current_state,
+                requested = %requested_state,
+                "KV mode transition ignored"
+            );
+        }
+    }
+}
+
 /// Storage State that is to be passed though the application
 #[derive(Clone)]
 pub struct Storage {
@@ -72,9 +131,7 @@ pub struct Storage {
     #[cfg(feature = "kv")]
     redis: Option<redis_store::RedisStore>,
     #[cfg(feature = "kv")]
-    kv_config: crate::config::KvConfig,
-    #[cfg(feature = "kv")]
-    kv_state: Arc<RwLock<kv::KvState>>,
+    kv_store: Arc<KvGlobalStore>,
 }
 
 type DeadPoolConnType = Object<AsyncPgConnection>;
@@ -153,7 +210,7 @@ impl Storage {
         schema: &str,
         runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
         #[cfg(feature = "kv")] redis: Option<redis_store::RedisStore>,
-        #[cfg(feature = "kv")] kv_config: &crate::config::KvConfig,
+        #[cfg(feature = "kv")] kv_store: Arc<KvGlobalStore>,
     ) -> error_stack::Result<Self, error::StorageError> {
         let pg_pool = Arc::new(Self::create_database_connection_pool(
             primary_config,
@@ -175,9 +232,7 @@ impl Storage {
             #[cfg(feature = "kv")]
             redis,
             #[cfg(feature = "kv")]
-            kv_config: kv_config.clone(),
-            #[cfg(feature = "kv")]
-            kv_state: Arc::new(RwLock::new(kv::KvState::Disabled)),
+            kv_store,
         })
     }
 
@@ -222,7 +277,7 @@ impl Storage {
             storage: StorageRuntimeConfigState {
                 use_replica: self.use_replica.load(Ordering::Acquire),
                 #[cfg(feature = "kv")]
-                kv_state: self.kv_state.read().await.to_string(),
+                kv_state: self.kv_store.state().await.to_string(),
             },
         }
     }
@@ -271,43 +326,10 @@ impl Storage {
         }
     }
 
-    /// Resolve `KvState` from runtime config; fail-closed to `Disabled` when absent.
+    /// Return the current KV state cached by the runtime-config poller.
     #[cfg(feature = "kv")]
     pub(crate) async fn kv_settings(&self) -> kv::KvState {
-        let requested_state = self
-            .runtime_config_manager
-            .get::<RuntimeConfigValues>()
-            .await
-            .map(|runtime_config_values| runtime_config_values.enable_kv)
-            .unwrap_or(kv::KvState::Disabled);
-
-        let current_state = *self.kv_state.read().await;
-        let can_enable_kv = if matches!(
-            (current_state, requested_state),
-            (kv::KvState::Disabled, kv::KvState::Enabled)
-        ) {
-            match &self.redis {
-                Some(redis) => redis.test().await.is_ok(),
-                None => false,
-            }
-        } else {
-            false
-        };
-
-        let current_state = self.kv_state.read().await;
-        let next_state = current_state.apply_transition(requested_state, can_enable_kv);
-        if next_state != *current_state {
-            crate::logger::info!(from = %*current_state, to = %next_state, "KV mode transition accepted");
-            *self.kv_state.write().await = next_state;
-        } else if requested_state != *current_state {
-            crate::logger::warn!(
-                current = %*current_state,
-                requested = %requested_state,
-                "KV mode transition ignored"
-            );
-        }
-
-        *current_state
+        self.kv_store.state().await
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
@@ -386,15 +408,15 @@ impl kv::RedisConnInterface for Storage {
 #[cfg(feature = "kv")]
 impl kv::KvStoreContext for Storage {
     fn ttl_for_kv(&self) -> u32 {
-        self.kv_config.ttl_for_kv
+        self.kv_store.config.ttl_for_kv
     }
 
     fn drainer_stream_name(&self, shard_key: &str) -> String {
-        self.kv_config.drainer_stream_name(shard_key)
+        self.kv_store.config.drainer_stream_name(shard_key)
     }
 
     fn drainer_num_partitions(&self) -> u8 {
-        self.kv_config.drainer_num_partitions
+        self.kv_store.config.drainer_num_partitions
     }
 }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -159,8 +159,7 @@ impl GlobalStore {
                     .inspect_err(|err| {
                         crate::logger::error!(
                             storage_runtime_config = "state_refresh",
-                            "error while checking redis connection, Error message: {}",
-                            err
+                            "error while checking redis connection, Error message: {err:?}",
                         );
                     })
                     .is_ok(),

--- a/src/storage/kv/scheme.rs
+++ b/src/storage/kv/scheme.rs
@@ -13,3 +13,60 @@ pub(crate) enum KvState {
     /// Insert to Postgres only; reads prefer Redis.
     SoftKill,
 }
+
+impl KvState {
+    pub(crate) fn apply_transition(self, requested: Self, can_enable_kv: bool) -> Self {
+        match (self, requested) {
+            (current, requested) if current == requested => current,
+            (Self::Disabled, Self::Enabled) if can_enable_kv => Self::Enabled,
+            (Self::Enabled, Self::SoftKill) => Self::SoftKill,
+            (Self::SoftKill, Self::Disabled) => Self::Disabled,
+            _ => self,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::KvState;
+
+    #[test]
+    fn applies_allowed_kv_state_transitions() {
+        assert_eq!(
+            KvState::Disabled.apply_transition(KvState::Enabled, true),
+            KvState::Enabled
+        );
+        assert_eq!(
+            KvState::Enabled.apply_transition(KvState::SoftKill, false),
+            KvState::SoftKill
+        );
+        assert_eq!(
+            KvState::SoftKill.apply_transition(KvState::Disabled, false),
+            KvState::Disabled
+        );
+    }
+
+    #[test]
+    fn ignores_disabled_to_enabled_without_redis() {
+        assert_eq!(
+            KvState::Disabled.apply_transition(KvState::Enabled, false),
+            KvState::Disabled
+        );
+    }
+
+    #[test]
+    fn ignores_unsupported_kv_state_transitions() {
+        assert_eq!(
+            KvState::Disabled.apply_transition(KvState::SoftKill, true),
+            KvState::Disabled
+        );
+        assert_eq!(
+            KvState::Enabled.apply_transition(KvState::Disabled, true),
+            KvState::Enabled
+        );
+        assert_eq!(
+            KvState::SoftKill.apply_transition(KvState::Enabled, true),
+            KvState::SoftKill
+        );
+    }
+}

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -25,7 +25,7 @@ impl std::fmt::Debug for RedisStore {
 }
 
 impl RedisStore {
-    pub async fn new(conf: &RedisSettings) -> error_stack::Result<Self, RedisError> {
+    pub(crate) async fn new(conf: &RedisSettings) -> error_stack::Result<Self, RedisError> {
         let pool = RedisConnectionPool::new(conf).await.map_err(into_report)?;
         Ok(Self {
             redis_conn: Arc::new(pool),
@@ -33,7 +33,7 @@ impl RedisStore {
     }
 
     /// A handle onto the same pool that namespaces every key with `key_prefix`.
-    pub fn clone_with_prefix(&self, key_prefix: &str) -> Self {
+    pub(crate) fn clone_with_prefix(&self, key_prefix: &str) -> Self {
         // `.as_ref().clone(..)` calls the pool's inherent `clone`, not `Arc::clone`.
         Self {
             redis_conn: Arc::new(self.redis_conn.as_ref().clone(key_prefix)),
@@ -41,7 +41,7 @@ impl RedisStore {
     }
 
     // Logs disconnects via `on_error`. `rx` stays bound (not `_`) so its `tx.send` succeeds.
-    pub fn spawn_error_watcher(&self) {
+    pub(crate) fn spawn_error_watcher(&self) {
         let redis_conn = self.redis_conn.clone();
         tokio::spawn(
             async move {
@@ -54,11 +54,11 @@ impl RedisStore {
 
     /// The shared pool. It manages (re)connection internally, so callers run
     /// commands directly and surface per-command errors themselves.
-    pub fn get_redis_conn(&self) -> Arc<RedisConnectionPool> {
+    pub(crate) fn get_redis_conn(&self) -> Arc<RedisConnectionPool> {
         self.redis_conn.clone()
     }
 
-    pub async fn test(&self) -> error_stack::Result<(), RedisError> {
+    pub(crate) async fn test(&self) -> error_stack::Result<(), RedisError> {
         let redis_conn = self.get_redis_conn();
         let key = consts::REDIS_HEALTH_CHECK_KEY.into();
         redis_conn

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -21,6 +21,8 @@ pub struct GlobalAppState {
     pub global_config: GlobalConfig,
     #[cfg(feature = "redis")]
     pub redis_store: Option<crate::storage::redis::RedisStore>,
+    #[cfg(feature = "kv")]
+    pub kv_store: Arc<crate::storage::KvGlobalStore>,
     pub runtime_config_manager: Arc<RuntimeConfigManager>,
 }
 
@@ -78,6 +80,9 @@ impl GlobalAppState {
             .expect("Failed to create runtime config manager"),
         );
 
+        #[cfg(feature = "kv")]
+        let kv_store = Arc::new(crate::storage::KvGlobalStore::new(global_config.kv.clone()));
+
         let tenants_app_state = {
             #[cfg(feature = "key_custodian")]
             {
@@ -97,6 +102,8 @@ impl GlobalAppState {
                         #[cfg(feature = "redis")]
                         redis_store.as_ref(),
                         runtime_config_manager.clone(),
+                        #[cfg(feature = "kv")]
+                        kv_store.clone(),
                     )
                     .await
                     .expect("Failed while configuring AppState for tenants");
@@ -115,6 +122,8 @@ impl GlobalAppState {
             global_config,
             #[cfg(feature = "redis")]
             redis_store,
+            #[cfg(feature = "kv")]
+            kv_store,
             runtime_config_manager,
         })
     }
@@ -141,6 +150,18 @@ impl GlobalAppState {
     pub async fn set_app_state(&self, state: TenantAppState) {
         let mut write_guard = self.tenants_app_state.write().await;
         write_guard.insert(state.config.tenant_id.clone(), Arc::new(state));
+    }
+
+    pub async fn apply_runtime_config_updates(&self) {
+        #[cfg(feature = "kv")]
+        {
+            self.kv_store
+                .refresh_from_runtime_config(
+                    &self.runtime_config_manager,
+                    self.redis_store.as_ref(),
+                )
+                .await;
+        }
     }
 
     #[cfg(feature = "key_custodian")]

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -8,7 +8,7 @@ use crate::config::TenantConfig;
 #[cfg(feature = "key_custodian")]
 use crate::routes::key_custodian::CustodianKeyState;
 use crate::{
-    api_client::ApiClient, app::TenantAppState, config::GlobalConfig, error::ApiError,
+    api_client::ApiClient, app::TenantAppState, config::GlobalConfig, error::ApiError, logger,
     runtime_config::RuntimeConfigManager,
 };
 
@@ -50,23 +50,18 @@ impl GlobalAppState {
         #[allow(clippy::expect_used)]
         let api_client = ApiClient::new(&global_config).expect("Failed to create api client");
 
-        // Shared pool; tenants derive key-prefixed handles. None if unconfigured or unreachable.
+        // Shared pool; tenants derive key-prefixed handles.
         #[cfg(feature = "redis")]
         let redis_store = match &global_config.redis {
-            Some(conf) => match crate::storage::redis::RedisStore::new(conf).await {
-                Ok(store) => {
-                    store.spawn_error_watcher();
-                    Some(store)
-                }
-                Err(err) => {
-                    crate::logger::error!(
-                        ?err,
-                        "Failed to initialize Redis; continuing without it"
-                    );
-                    None
-                }
-            },
-            None => None,
+            Some(conf) => Some(
+                crate::storage::redis::RedisStore::new(conf)
+                    .await
+                    .inspect_err(|err| {
+                        crate::logger::error!(?err, "Failed to initialize Redis;");
+                    })
+                    .expect("Failed to initialize Redis"),
+            ),
+            None => panic!("Redis configuration is required when Redis support is enabled"),
         };
 
         #[allow(clippy::expect_used)]
@@ -169,7 +164,14 @@ impl GlobalAppState {
                 // evaluated lazily only when runtime config tries to enable replica reads.
                 let tenant_app_state = self.tenants_app_state.read().await.values().next().cloned();
                 match tenant_app_state {
-                    Some(tenant_app_state) => tenant_app_state.db.get_replica_conn().await.is_ok(),
+                    Some(tenant_app_state) => tenant_app_state
+                        .db
+                        .get_replica_conn()
+                        .await
+                        .inspect_err(|err| {
+                            logger::error!("Error while checking read replica connection: {}", err)
+                        })
+                        .is_ok(),
                     None => false,
                 }
             })

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -147,8 +147,6 @@ impl GlobalAppState {
     }
 
     pub async fn set_app_state(&self, state: TenantAppState) {
-        state.db.refresh_replica_state_from_runtime_config().await;
-
         let mut write_guard = self.tenants_app_state.write().await;
         write_guard.insert(state.config.tenant_id.clone(), Arc::new(state));
     }
@@ -164,16 +162,18 @@ impl GlobalAppState {
                 .await;
         }
 
-        // `use_replica` is global, but replica availability is still checked through a tenant
-        // `Storage` because the replica pool is owned there. Any tenant handle is sufficient to
-        // validate the shared replica config and update the global routing state.
-        let tenant_app_state = self.tenants_app_state.read().await.values().next().cloned();
-        if let Some(tenant_app_state) = tenant_app_state {
-            tenant_app_state
-                .db
-                .refresh_replica_state_from_runtime_config()
-                .await;
-        }
+        self.storage_global_store
+            .refresh_replica_state_from_runtime_config(&self.runtime_config_manager, || async {
+                // `use_replica` is global, but replica availability is verified through a
+                // tenant `Storage` because the replica pool is owned there. The health check is
+                // evaluated lazily only when runtime config tries to enable replica reads.
+                let tenant_app_state = self.tenants_app_state.read().await.values().next().cloned();
+                match tenant_app_state {
+                    Some(tenant_app_state) => tenant_app_state.db.get_replica_conn().await.is_ok(),
+                    None => false,
+                }
+            })
+            .await;
     }
 
     #[cfg(feature = "key_custodian")]

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -21,8 +21,7 @@ pub struct GlobalAppState {
     pub global_config: GlobalConfig,
     #[cfg(feature = "redis")]
     pub redis_store: Option<crate::storage::redis::RedisStore>,
-    #[cfg(feature = "kv")]
-    pub kv_store: Arc<crate::storage::KvGlobalStore>,
+    pub storage_global_store: Arc<crate::storage::GlobalStore>,
     pub runtime_config_manager: Arc<RuntimeConfigManager>,
 }
 
@@ -80,8 +79,10 @@ impl GlobalAppState {
             .expect("Failed to create runtime config manager"),
         );
 
-        #[cfg(feature = "kv")]
-        let kv_store = Arc::new(crate::storage::KvGlobalStore::new(global_config.kv.clone()));
+        let storage_global_store = Arc::new(crate::storage::GlobalStore::new(
+            #[cfg(feature = "kv")]
+            global_config.kv.clone(),
+        ));
 
         let tenants_app_state = {
             #[cfg(feature = "key_custodian")]
@@ -102,8 +103,7 @@ impl GlobalAppState {
                         #[cfg(feature = "redis")]
                         redis_store.as_ref(),
                         runtime_config_manager.clone(),
-                        #[cfg(feature = "kv")]
-                        kv_store.clone(),
+                        storage_global_store.clone(),
                     )
                     .await
                     .expect("Failed while configuring AppState for tenants");
@@ -122,8 +122,7 @@ impl GlobalAppState {
             global_config,
             #[cfg(feature = "redis")]
             redis_store,
-            #[cfg(feature = "kv")]
-            kv_store,
+            storage_global_store,
             runtime_config_manager,
         })
     }
@@ -148,6 +147,8 @@ impl GlobalAppState {
     }
 
     pub async fn set_app_state(&self, state: TenantAppState) {
+        state.db.refresh_replica_state_from_runtime_config().await;
+
         let mut write_guard = self.tenants_app_state.write().await;
         write_guard.insert(state.config.tenant_id.clone(), Arc::new(state));
     }
@@ -155,11 +156,22 @@ impl GlobalAppState {
     pub async fn apply_runtime_config_updates(&self) {
         #[cfg(feature = "kv")]
         {
-            self.kv_store
-                .refresh_from_runtime_config(
+            self.storage_global_store
+                .refresh_kv_state_from_runtime_config(
                     &self.runtime_config_manager,
                     self.redis_store.as_ref(),
                 )
+                .await;
+        }
+
+        // `use_replica` is global, but replica availability is still checked through a tenant
+        // `Storage` because the replica pool is owned there. Any tenant handle is sufficient to
+        // validate the shared replica config and update the global routing state.
+        let tenant_app_state = self.tenants_app_state.read().await.values().next().cloned();
+        if let Some(tenant_app_state) = tenant_app_state {
+            tenant_app_state
+                .db
+                .refresh_replica_state_from_runtime_config()
                 .await;
         }
     }

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -52,6 +52,7 @@ impl GlobalAppState {
 
         // Shared pool; tenants derive key-prefixed handles.
         #[cfg(feature = "redis")]
+        #[allow(clippy::expect_used)]
         let redis_store = match &global_config.redis {
             Some(conf) => Some(
                 crate::storage::redis::RedisStore::new(conf)

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -62,7 +62,7 @@ impl GlobalAppState {
                     })
                     .expect("Failed to initialize Redis"),
             ),
-            None => panic!("Redis configuration is required when Redis support is enabled"),
+            None => None,
         };
 
         #[allow(clippy::expect_used)]

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -57,6 +57,7 @@ impl GlobalAppState {
             Some(conf) => Some(
                 crate::storage::redis::RedisStore::new(conf)
                     .await
+                    .inspect(|redis_conn| redis_conn.spawn_error_watcher())
                     .inspect_err(|err| {
                         crate::logger::error!(?err, "Failed to initialize Redis;");
                     })


### PR DESCRIPTION
## Summary
- validate runtime KV mode transitions and ignore unsupported switches
- keep KV enablement global, refresh it from runtime config, and only move to enabled after Redis health validation succeeds
- fail server startup when Redis is configured but the Redis connection cannot be established
- track read-replica enablement globally and probe replica availability only while enabling replica reads
- expose runtime config status for KV and read-replica state visibility

## Testing
### Transition from Disabled to SoftKill failed.
<img width="1154" height="105" alt="image" src="https://github.com/user-attachments/assets/90466bf9-9926-4397-a9be-6c6cd42dd59d" />
<img width="1600" height="1274" alt="image" src="https://github.com/user-attachments/assets/01e111c2-d06e-478b-b907-223042913f96" />

- `cargo test --features kv kv::scheme::tests`
- `cargo check --features kv`