### PR TITLE
feat: add custodian status endpoints for tenants

### DIFF
--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -1,6 +1,11 @@
 use std::sync::Arc;
 
-use axum::{Json, extract::State, routing::post};
+use axum::{
+    Json,
+    extract::Path,
+    extract::State,
+    routing::{get, post},
+};
 use error_stack::ResultExt;
 use hyperswitch_masking::{ExposeInterface, Secret};
 
@@ -50,6 +55,13 @@ pub struct CustodianRespPayload {
     pub message: String,
 }
 
+/// Api response model for custodian status routes
+#[derive(serde::Serialize, Debug)]
+pub struct CustodianStatus {
+    pub tenant_id: String,
+    pub unlocked: bool,
+}
+
 ///
 /// Function for registering routes that is specifically handling the custodian apis
 ///
@@ -58,6 +70,8 @@ pub fn serve() -> axum::Router<Arc<GlobalAppState>> {
         .route("/key1", post(key1))
         .route("/key2", post(key2))
         .route("/decrypt", post(decrypt))
+        .route("/status", get(status_all))
+        .route("/status/:tenant_id", get(status))
 }
 
 /// Handler for `/custodian/key1`
@@ -151,6 +165,53 @@ pub async fn decrypt(
             Err(inner_err)?
         }
     }
+}
+
+/// Handler for `/custodian/status/:tenant_id`
+/// Returns 200 when the custodian is unlocked for the tenant, 423 otherwise.
+#[tracing::instrument(skip_all)]
+pub async fn status(
+    State(global_app_state): State<Arc<GlobalAppState>>,
+    Path(tenant_id): Path<String>,
+) -> Result<Json<CustodianStatus>, hyper::StatusCode> {
+    let unlocked = global_app_state
+        .get_custodian_status(&tenant_id)
+        .await
+        .map_err(|_| hyper::StatusCode::BAD_REQUEST)?;
+
+    if !unlocked {
+        return Err(hyper::StatusCode::LOCKED);
+    }
+
+    Ok(Json(CustodianStatus {
+        tenant_id,
+        unlocked,
+    }))
+}
+
+/// Handler for `/custodian/status` (all tenants)
+/// Returns 200 only when every tenant is unlocked; 423 with the full status list otherwise.
+#[tracing::instrument(skip_all)]
+pub async fn status_all(
+    State(global_app_state): State<Arc<GlobalAppState>>,
+) -> (hyper::StatusCode, Json<Vec<CustodianStatus>>) {
+    let mut statuses: Vec<CustodianStatus> = global_app_state
+        .get_all_custodian_statuses()
+        .await
+        .into_iter()
+        .map(|(tenant_id, unlocked)| CustodianStatus {
+            tenant_id,
+            unlocked,
+        })
+        .collect();
+
+    statuses.sort_by(|a, b| a.tenant_id.cmp(&b.tenant_id));
+
+    if statuses.iter().any(|status| !status.unlocked) {
+        return (hyper::StatusCode::LOCKED, Json(statuses));
+    }
+
+    (hyper::StatusCode::OK, Json(statuses))
 }
 
 async fn aes_decrypt_custodian_key(

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -2,8 +2,7 @@ use std::sync::Arc;
 
 use axum::{
     Json,
-    extract::Path,
-    extract::State,
+    extract::{Path, State},
     routing::{get, post},
 };
 use error_stack::ResultExt;

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -154,4 +154,21 @@ impl GlobalAppState {
             .transpose()?;
         Ok(())
     }
+
+    #[cfg(feature = "key_custodian")]
+    /// Returns whether the custodian has been unlocked for a known tenant.
+    pub async fn get_custodian_status(&self, tenant_id: &str) -> Result<bool, ApiError> {
+        self.is_known_tenant(tenant_id)?;
+        Ok(self.tenants_app_state.read().await.contains_key(tenant_id))
+    }
+
+    #[cfg(feature = "key_custodian")]
+    /// Returns the custodian unlocked status for every known tenant.
+    pub async fn get_all_custodian_statuses(&self) -> FxHashMap<String, bool> {
+        let app_states = self.tenants_app_state.read().await;
+        self.known_tenants
+            .iter()
+            .map(|tenant_id| (tenant_id.clone(), app_states.contains_key(tenant_id)))
+            .collect()
+    }
 }


### PR DESCRIPTION
This pull request adds new API endpoints to expose the status of the key custodian for tenants, along with the necessary data structures and backend methods to support these endpoints. The main changes include introducing `/custodian/status` and `/custodian/status/:tenant_id` routes, implementing their handlers, and adding corresponding methods in `GlobalAppState` to retrieve custodian status information.

### API Additions

* Added a new `CustodianStatus` response model to represent the custodian status for tenants.
* Registered two new GET routes: `/custodian/status` (returns status for all tenants) and `/custodian/status/:tenant_id` (returns status for a specific tenant).

### Endpoint Handlers

* Implemented the `status` handler for `/custodian/status/:tenant_id`, which returns 200 if the custodian is unlocked for the tenant, or 423 if locked.
* Implemented the `status_all` handler for `/custodian/status`, which returns 200 if all tenants are unlocked, or 423 with the status of all tenants otherwise.

### Backend Support

* Added `get_custodian_status` and `get_all_custodian_statuses` methods to `GlobalAppState` to fetch custodian unlock status for a tenant or all tenants, respectively.