### PR TITLE
fix(kv): preserve insert uniqueness routing

### DIFF
--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,8 @@
 [default]
 check-filename = true
+extend-ignore-re = [
+  '\b[0-9a-f]{7,40}\b',
+]
 
 [default.extend-words]
 encrypter = "encrypter"

--- a/.typos.toml
+++ b/.typos.toml
@@ -6,6 +6,7 @@ encrypter = "encrypter"
 requestor = "requestor"
 Hashi = "Hashi"
 kms = "kms"
+9260ba2 = "9260ba2"
 
 [files]
 extend-exclude = ["loadtest/scripts/http-rs.js"]

--- a/.typos.toml
+++ b/.typos.toml
@@ -1,5 +1,6 @@
 [default]
 check-filename = true
+# regex for matching commit hash values in CHANGELOG.md
 extend-ignore-re = [
   '\b[0-9a-f]{7,40}\b',
 ]

--- a/.typos.toml
+++ b/.typos.toml
@@ -9,7 +9,6 @@ encrypter = "encrypter"
 requestor = "requestor"
 Hashi = "Hashi"
 kms = "kms"
-9260ba2 = "9260ba2"
 
 [files]
 extend-exclude = ["loadtest/scripts/http-rs.js"]

--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -53,6 +53,12 @@ impl KvResource for Fingerprint {
 
     type PrimaryKeyType = FingerprintPrimaryKey;
 
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType {
+        FingerprintPrimaryKey {
+            fingerprint_hash: new_object.fingerprint_hash.clone(),
+        }
+    }
+
     fn set_storage_scheme(new_object: &mut Self::DieselNew, scheme: StorageScheme) {
         new_object.updated_by = Some(scheme);
     }
@@ -85,7 +91,6 @@ impl KvResource for Fingerprint {
 
         Ok(output)
     }
-
     async fn storage_find(
         store: &Storage,
         pk: &Self::PrimaryKeyType,

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -50,6 +50,12 @@ impl KvResource for HashTable {
 
     type PrimaryKeyType = HashTablePrimaryKey;
 
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType {
+        HashTablePrimaryKey {
+            data_hash: new_object.data_hash.clone(),
+        }
+    }
+
     fn set_storage_scheme(new_object: &mut Self::DieselNew, scheme: StorageScheme) {
         new_object.updated_by = Some(scheme);
     }
@@ -81,7 +87,6 @@ impl KvResource for HashTable {
 
         Ok(output)
     }
-
     async fn storage_find(
         store: &Storage,
         pk: &Self::PrimaryKeyType,

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -132,6 +132,14 @@ impl KvResource for Locker {
 
     type PrimaryKeyType = LockerPrimaryKeyType;
 
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType {
+        LockerPrimaryKeyType {
+            locker_id: new_object.locker_id.clone(),
+            merchant_id: new_object.merchant_id.clone(),
+            customer_id: new_object.customer_id.clone(),
+        }
+    }
+
     fn set_storage_scheme(new_object: &mut Self::DieselNew, scheme: StorageScheme) {
         new_object.updated_by = Some(scheme);
     }

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -52,6 +52,12 @@ impl KvResource for ReverseLookup {
 
     type PrimaryKeyType = ReverseLookupPrimaryKey;
 
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType {
+        ReverseLookupPrimaryKey {
+            lookup_id: new_object.lookup_id.clone(),
+        }
+    }
+
     fn set_storage_scheme(new_object: &mut Self::DieselNew, scheme: StorageScheme) {
         new_object.updated_by = scheme.to_string();
     }
@@ -84,7 +90,6 @@ impl KvResource for ReverseLookup {
         .await?;
         Ok(reverse_lookup)
     }
-
     async fn storage_find(
         store: &Storage,
         pk: &Self::PrimaryKeyType,

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -1,5 +1,6 @@
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use diesel_async::RunQueryDsl;
+use hyperswitch_masking::PeekInterface;
 
 use crate::{
     error::{ContainerError, VaultDBError},
@@ -65,6 +66,13 @@ impl KvResource for Vault {
 
     type PrimaryKeyType = VaultPrimaryKey;
 
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType {
+        VaultPrimaryKey {
+            entity_id: new_object.entity_id().to_string(),
+            vault_id: new_object.vault_id().peek().clone(),
+        }
+    }
+
     fn set_storage_scheme(new_object: &mut Self::DieselNew, scheme: StorageScheme) {
         new_object.set_updated_by(scheme);
     }
@@ -95,7 +103,6 @@ impl KvResource for Vault {
         .await?;
         Ok(output)
     }
-
     async fn storage_find(
         store: &Storage,
         pk: &Self::PrimaryKeyType,

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -15,7 +15,7 @@ use super::{
 };
 use crate::{
     error::{
-        ContainerError, StorageErrorExt,
+        ContainerError, ReverseLookupDBError, StorageErrorExt,
         kv::{KvError, RedisErrorExt},
     },
     observability::metrics,
@@ -232,6 +232,24 @@ where
     kv_backend_error::<E>(Report::new(KvError::DuplicateValue {
         key: key.to_string(),
     }))
+}
+
+fn reverse_lookup_insert_error_to_resource_error<E>(
+    lookup_id: &str,
+    err: ContainerError<ReverseLookupDBError>,
+) -> ContainerError<E>
+where
+    E: for<'a> From<&'a KvError> + error_stack::Context,
+{
+    let kv_error = if err.get_inner().is_duplicate() {
+        KvError::DuplicateValue {
+            key: lookup_id.to_string(),
+        }
+    } else {
+        KvError::Backend
+    };
+
+    kv_backend_error::<E>(err.error.change_context(kv_error))
 }
 
 #[derive(Clone, Default)]
@@ -507,7 +525,7 @@ where
             let partition_key_str = partition_key.to_string();
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
-                if let Err(err) = store
+                store
                     .insert_reverse_lookup(types::ReverseLookupNew {
                         lookup_id: lookup_id.clone(),
                         secondary_key: partition_key_str.clone(),
@@ -516,17 +534,9 @@ where
                         updated_by: scheme.to_string(),
                     })
                     .await
-                {
-                    return Err(if err.get_inner().is_duplicate() {
-                        kv_duplicate_error::<M::Error>(&lookup_id)
-                    } else {
-                        kv_backend_error::<M::Error>(
-                            Report::new(KvError::Backend).attach_printable(format!(
-                                "failed to insert reverse lookup record: {err}"
-                            )),
-                        )
-                    });
-                }
+                    .map_err(|err| {
+                        reverse_lookup_insert_error_to_resource_error::<M::Error>(&lookup_id, err)
+                    })?;
             }
 
             let diesel_entity = diesel_new.into();

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -90,6 +90,9 @@ pub(crate) trait KvResource:
     /// Redis for primary-key based insert, find, update, and delete operations.
     type PrimaryKeyType: GetPartitionKey;
 
+    /// Reconstruct the primary key from the insert payload for insert-time conflict checks.
+    fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType;
+
     /// Mark a new record with the storage scheme selected for the insert.
     fn set_storage_scheme(diesel_new: &mut Self::DieselNew, scheme: StorageScheme);
 
@@ -272,14 +275,156 @@ async fn decide_storage_scheme_for_find_operation(store: &Storage) -> DecidedSto
     }
 }
 
-async fn decide_storage_scheme_for_insert_operation(store: &Storage) -> DecidedStorageScheme {
+/// Decide where an insert should be written for the current KV runtime state.
+///
+/// The insert path is more conservative than reads because accepting a Redis write for a
+/// row that already exists only in PostgreSQL would bypass PostgreSQL's unique constraints
+/// until drainer replay. This is especially important during KV enablement, when older
+/// records may not have Redis entries yet.
+///
+/// Decision summary:
+/// - `Disabled`: write directly to PostgreSQL.
+/// - `Enabled`: check Redis first. If Redis has no knowledge of the key, check PostgreSQL
+///   with `storage_find`; an existing PostgreSQL row is returned as duplicate, otherwise
+///   the insert can proceed through KV.
+/// - `SoftKill`: check Redis first. Tombstoned keys stay on KV to preserve drainer-delay
+///   ordering; completely absent keys write to PostgreSQL.
+async fn decide_storage_scheme_for_insert_operation<M>(
+    store: &Storage,
+    diesel_new: &M::DieselNew,
+    partition_key: &PartitionKey<'_>,
+    reverse_lookup_key: Option<&ReverseLookupKey>,
+) -> Result<DecidedStorageScheme, ContainerError<M::Error>>
+where
+    M: KvResource,
+{
     let state = store.kv_settings().await;
     match state {
-        // in disabled and softkill mode, always push new inserts to PG
-        KvState::Disabled | KvState::SoftKill => DecidedStorageScheme::PostgresOnly,
-        KvState::Enabled => store
-            .kv_backend()
-            .map_or(DecidedStorageScheme::PostgresOnly, DecidedStorageScheme::Kv),
+        // KV is fully disabled, so PostgreSQL remains the source of truth for inserts.
+        KvState::Disabled => Ok(DecidedStorageScheme::PostgresOnly),
+        KvState::Enabled => {
+            let Some(kv_backend) = store.kv_backend() else {
+                return Ok(DecidedStorageScheme::PostgresOnly);
+            };
+
+            // First honor any existing Redis state: present keys are duplicates and
+            // tombstoned keys must remain on KV so pending deletes can drain safely.
+            match decide_insert_scheme_from_kv_state::<M>(
+                kv_backend.clone(),
+                partition_key,
+                reverse_lookup_key,
+            )
+            .await?
+            {
+                Some(decided_scheme) => Ok(decided_scheme),
+                None => {
+                    // Redis is absent. Check PostgreSQL before writing to KV so records
+                    // created before KV enablement still enforce their DB uniqueness.
+                    let primary_key = M::get_primary_key_from_new_object(diesel_new);
+                    match M::storage_find(store, &primary_key).await {
+                        Ok(_) => Err(kv_duplicate_error::<M::Error>(&partition_key.to_string())),
+                        Err(err) if err.get_inner().is_not_found() => {
+                            Ok(DecidedStorageScheme::Kv(kv_backend))
+                        }
+                        Err(err) => Err(err),
+                    }
+                }
+            }
+        }
+        KvState::SoftKill => {
+            let Some(kv_backend) = store.kv_backend() else {
+                return Ok(DecidedStorageScheme::PostgresOnly);
+            };
+
+            // In soft-kill, only keys already tracked by Redis stay on KV. Fully absent
+            // keys move to PostgreSQL as part of draining traffic away from KV.
+            Ok(decide_insert_scheme_from_kv_state::<M>(
+                kv_backend,
+                partition_key,
+                reverse_lookup_key,
+            )
+            .await?
+            .unwrap_or(DecidedStorageScheme::PostgresOnly))
+        }
+    }
+}
+
+/// Inspect Redis state for an insert key and return a forced decision when Redis is
+/// authoritative for the key.
+///
+/// Return values:
+/// - `Ok(Some(Kv(_)))`: Redis contains a tombstone, so re-insert through KV and let the
+///   drainer serialize the pending delete/insert effects.
+/// - `Err(Duplicate)`: Redis contains a live primary or reverse-lookup record, so a new
+///   insert would violate uniqueness.
+/// - `Ok(None)`: both the primary key and optional reverse lookup key are absent from
+///   Redis; the caller must decide whether to check PostgreSQL or write there directly.
+///
+/// Backend errors are propagated because treating Redis failures as misses could route
+/// duplicate or tombstoned records to PostgreSQL incorrectly.
+async fn decide_insert_scheme_from_kv_state<M>(
+    kv_backend: KvBackend,
+    partition_key: &PartitionKey<'_>,
+    reverse_lookup_key: Option<&ReverseLookupKey>,
+) -> Result<Option<DecidedStorageScheme>, ContainerError<M::Error>>
+where
+    M: KvResource,
+{
+    // Step 1: check the primary Redis key.
+    let partition_key_str = partition_key.to_string();
+    match kv_backend
+        .find::<M::DieselEntity>(partition_key.clone())
+        .await
+    {
+        // A live primary key means the insert is a duplicate.
+        Ok(KvFindResult::Present(_)) => Err(kv_duplicate_error::<M::Error>(&partition_key_str)),
+        // A tombstone means a delete may still be draining; re-insert through KV.
+        Ok(KvFindResult::Deleted) => Ok(Some(DecidedStorageScheme::Kv(kv_backend))),
+        Ok(KvFindResult::Absent) => {
+            metrics::KV_CACHE_MISS_COUNT.add(
+                1,
+                metrics_utils::metric_attributes![("resource", M::ENTITY_TYPE)],
+            );
+
+            // Step 2: resources without a secondary uniqueness key have no more Redis
+            // state to consult.
+            let Some(reverse_lookup_key) = reverse_lookup_key else {
+                return Ok(None);
+            };
+
+            // Step 3: check the reverse lookup key for resources whose logical insert
+            // uniqueness is represented by a secondary Redis key.
+            let reverse_lookup_partition_key = PartitionKey::ReverseLookup {
+                lookup_id: &reverse_lookup_key.lookup_id,
+            };
+            let reverse_lookup_key_str = reverse_lookup_partition_key.to_string();
+
+            match kv_backend
+                .find::<types::ReverseLookup>(reverse_lookup_partition_key)
+                .await
+            {
+                // A live reverse lookup means another live row owns the logical key.
+                Ok(KvFindResult::Present(_)) => Err(kv_duplicate_error::<M::Error>(
+                    &reverse_lookup_key.lookup_id,
+                )),
+                // A reverse-lookup tombstone is still KV-tracked and should be replaced
+                // through KV rather than bypassed via PostgreSQL.
+                Ok(KvFindResult::Deleted) => Ok(Some(DecidedStorageScheme::Kv(kv_backend))),
+                Ok(KvFindResult::Absent) => {
+                    metrics::KV_CACHE_MISS_COUNT.add(
+                        1,
+                        metrics_utils::metric_attributes![("resource", M::ENTITY_TYPE)],
+                    );
+                    Ok(None)
+                }
+                Err(e) => Err(kv_backend_error::<M::Error>(
+                    e.to_redis_failed_response(&reverse_lookup_key_str),
+                )),
+            }
+        }
+        Err(e) => Err(kv_backend_error::<M::Error>(
+            e.to_redis_failed_response(&partition_key_str),
+        )),
     }
 }
 
@@ -341,7 +486,14 @@ where
     M: KvResource,
     F: FnOnce(&M::DieselNew, &PartitionKey<'_>) -> Option<ReverseLookupKey>,
 {
-    let decided_scheme = decide_storage_scheme_for_insert_operation(store).await;
+    let reverse_lookup_key = get_reverse_lookup_key(&diesel_new, &partition_key);
+    let decided_scheme = decide_storage_scheme_for_insert_operation::<M>(
+        store,
+        &diesel_new,
+        &partition_key,
+        reverse_lookup_key.as_ref(),
+    )
+    .await?;
     log_storage_scheme_decision(M::ENTITY_TYPE, "insert", &decided_scheme);
     let scheme = decided_scheme.storage_scheme();
     M::set_storage_scheme(&mut diesel_new, scheme);
@@ -353,23 +505,28 @@ where
                 .map_err(kv_backend_error::<M::Error>)?;
 
             let partition_key_str = partition_key.to_string();
-            if let Some(reverse_lookup_key) = get_reverse_lookup_key(&diesel_new, &partition_key) {
-                store
+            if let Some(reverse_lookup_key) = reverse_lookup_key {
+                let lookup_id = reverse_lookup_key.lookup_id.clone();
+                if let Err(err) = store
                     .insert_reverse_lookup(types::ReverseLookupNew {
-                        lookup_id: reverse_lookup_key.lookup_id.clone(),
+                        lookup_id: lookup_id.clone(),
                         secondary_key: partition_key_str.clone(),
                         partition_key: partition_key_str.clone(),
                         source: M::ENTITY_TYPE.to_string(),
                         updated_by: scheme.to_string(),
                     })
                     .await
-                    .map_err(|err| {
+                {
+                    return Err(if err.get_inner().is_duplicate() {
+                        kv_duplicate_error::<M::Error>(&lookup_id)
+                    } else {
                         kv_backend_error::<M::Error>(
                             Report::new(KvError::Backend).attach_printable(format!(
                                 "failed to insert reverse lookup record: {err}"
                             )),
                         )
-                    })?;
+                    });
+                }
             }
 
             let diesel_entity = diesel_new.into();

--- a/src/storage/storage_v2/types.rs
+++ b/src/storage/storage_v2/types.rs
@@ -150,4 +150,14 @@ impl VaultNewInner {
     pub fn set_updated_by(&mut self, updated_by: StorageScheme) {
         self.updated_by = Some(updated_by);
     }
+
+    #[cfg(feature = "kv")]
+    pub(crate) fn vault_id(&self) -> &Secret<String> {
+        &self.vault_id
+    }
+
+    #[cfg(feature = "kv")]
+    pub(crate) fn entity_id(&self) -> &str {
+        &self.entity_id
+    }
 }


### PR DESCRIPTION
**Summary**
- Bottom PR in stack #195.
- Preserves insert-time uniqueness while KV is enabled by checking Redis state first and falling back to PostgreSQL conflict checks before routing absent keys to KV.
- Keeps Redis tombstoned keys on the KV path to preserve drainer-delay ordering.
- Adds primary-key reconstruction support needed for insert-time PostgreSQL conflict checks across KV resources.
- Moves `.typos.toml` commit-hash ignores into the bottom layer so spell checks pass for every PR in the stack.

**Stack**
- Base: `main`
- Next: #194
- Top: #192

**Validation**
- `cargo check --features kv`