### PR TITLE
fix(kv): use secondary keys for hash fields

### DIFF
--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -129,7 +129,7 @@ impl super::LockerInterface for Storage {
         #[cfg(feature = "kv")]
         {
             return super::kv::insert_resource_with_reverse_lookup::<types::Locker>(self, new)
-            .await;
+                .await;
         }
 
         #[cfg(not(feature = "kv"))]
@@ -362,8 +362,7 @@ impl super::HashInterface for Storage {
                 created_at: crate::utils::date_time::now(),
                 updated_by: Some(StorageScheme::PostgresOnly),
             };
-            return super::kv::insert_resource::<types::HashTable>(self, hash_table_new)
-            .await;
+            return super::kv::insert_resource::<types::HashTable>(self, hash_table_new).await;
         }
 
         #[cfg(not(feature = "kv"))]
@@ -521,8 +520,7 @@ impl super::FingerprintInterface for Storage {
                 fingerprint_id,
                 updated_by: Some(StorageScheme::PostgresOnly),
             };
-            return super::kv::insert_resource::<types::Fingerprint>(self, finger_print_new)
-            .await;
+            return super::kv::insert_resource::<types::Fingerprint>(self, finger_print_new).await;
         }
 
         #[cfg(not(feature = "kv"))]
@@ -624,7 +622,9 @@ impl super::ReverseLookupInterface for Storage {
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
         #[cfg(feature = "kv")]
         {
-            return Box::pin(super::kv::insert_resource::<types::ReverseLookup>(self, new))
+            return Box::pin(super::kv::insert_resource::<types::ReverseLookup>(
+                self, new,
+            ))
             .await;
         }
 

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -4,8 +4,6 @@ use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use diesel_async::{AsyncConnection, RunQueryDsl};
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
-#[cfg(feature = "kv")]
-use hyperswitch_masking::PeekInterface;
 use hyperswitch_masking::Secret;
 
 use super::{
@@ -130,13 +128,11 @@ impl super::LockerInterface for Storage {
     ) -> Result<types::Locker, ContainerError<Self::Error>> {
         #[cfg(feature = "kv")]
         {
-            let locker_id = new.locker_id.peek().clone();
             let merchant_id = new.merchant_id.clone();
             let customer_id = new.customer_id.clone();
             let partition_key = super::kv::PartitionKey::Locker {
                 merchant_id: &merchant_id,
                 customer_id: &customer_id,
-                locker_id: &locker_id,
             };
 
             return super::kv::insert_resource_with_reverse_lookup::<types::Locker>(

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -128,18 +128,7 @@ impl super::LockerInterface for Storage {
     ) -> Result<types::Locker, ContainerError<Self::Error>> {
         #[cfg(feature = "kv")]
         {
-            let merchant_id = new.merchant_id.clone();
-            let customer_id = new.customer_id.clone();
-            let partition_key = super::kv::PartitionKey::Locker {
-                merchant_id: &merchant_id,
-                customer_id: &customer_id,
-            };
-
-            return super::kv::insert_resource_with_reverse_lookup::<types::Locker>(
-                self,
-                new,
-                partition_key,
-            )
+            return super::kv::insert_resource_with_reverse_lookup::<types::Locker>(self, new)
             .await;
         }
 
@@ -373,16 +362,7 @@ impl super::HashInterface for Storage {
                 created_at: crate::utils::date_time::now(),
                 updated_by: Some(StorageScheme::PostgresOnly),
             };
-            let data_hash = hash_table_new.data_hash.clone();
-            let partition_key = super::kv::PartitionKey::HashTable {
-                data_hash: &data_hash,
-            };
-
-            return super::kv::insert_resource::<types::HashTable>(
-                self,
-                hash_table_new,
-                partition_key,
-            )
+            return super::kv::insert_resource::<types::HashTable>(self, hash_table_new)
             .await;
         }
 
@@ -541,15 +521,7 @@ impl super::FingerprintInterface for Storage {
                 fingerprint_id,
                 updated_by: Some(StorageScheme::PostgresOnly),
             };
-            let partition_key = super::kv::PartitionKey::Fingerprint {
-                fingerprint_hash: &fingerprint_hash,
-            };
-
-            return super::kv::insert_resource::<types::Fingerprint>(
-                self,
-                finger_print_new,
-                partition_key,
-            )
+            return super::kv::insert_resource::<types::Fingerprint>(self, finger_print_new)
             .await;
         }
 
@@ -652,16 +624,7 @@ impl super::ReverseLookupInterface for Storage {
     ) -> Result<types::ReverseLookup, ContainerError<Self::Error>> {
         #[cfg(feature = "kv")]
         {
-            let lookup_id = new.lookup_id.clone();
-            let partition_key = super::kv::PartitionKey::ReverseLookup {
-                lookup_id: &lookup_id,
-            };
-
-            return Box::pin(super::kv::insert_resource::<types::ReverseLookup>(
-                self,
-                new,
-                partition_key,
-            ))
+            return Box::pin(super::kv::insert_resource::<types::ReverseLookup>(self, new))
             .await;
         }
 

--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -12,7 +12,7 @@ use crate::{
             PartitionKey, StorageScheme,
             entity::EntityType,
             partition_key::KvStorePartition,
-            resource::{DirectInsert, GetPartitionKey, KvResource},
+            resource::{DirectInsert, GetPartitionKey, GetSecondaryKey, KvResource, SecondaryKey},
             serializable_query::{SerializableQuery, generate_insert_query},
         },
         types::{Fingerprint, FingerprintTableNew},
@@ -39,6 +39,12 @@ impl GetPartitionKey for FingerprintPrimaryKey {
         PartitionKey::Fingerprint {
             fingerprint_hash: &self.fingerprint_hash,
         }
+    }
+}
+
+impl GetSecondaryKey for FingerprintPrimaryKey {
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.get_partition_key().to_string())
     }
 }
 

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -10,7 +10,7 @@ use crate::{
             StorageScheme,
             entity::EntityType,
             partition_key::{KvStorePartition, PartitionKey},
-            resource::{DirectInsert, GetPartitionKey, KvResource},
+            resource::{DirectInsert, GetPartitionKey, GetSecondaryKey, KvResource, SecondaryKey},
             serializable_query::{SerializableQuery, generate_insert_query},
         },
         types::{HashTable, HashTableNew},
@@ -36,6 +36,12 @@ impl GetPartitionKey for HashTablePrimaryKey {
         PartitionKey::HashTable {
             data_hash: &self.data_hash,
         }
+    }
+}
+
+impl GetSecondaryKey for HashTablePrimaryKey {
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.get_partition_key().to_string())
     }
 }
 

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -11,8 +11,9 @@ use crate::{
             entity::EntityType,
             partition_key::{KvStorePartition, PartitionKey},
             resource::{
-                GetLookupKey, GetPartitionKey, KvDeletableResource, KvDeletableWithLookup,
-                KvResource, KvSecondaryLookupResource, ReverseLookupInsert, ReverseLookupKey,
+                GetLookupKey, GetPartitionKey, GetSecondaryKey, KvDeletableResource,
+                KvDeletableWithLookup, KvResource, KvSecondaryLookupResource, ReverseLookupInsert,
+                ReverseLookupKey, SecondaryKey,
             },
             serializable_query::{SerializableQuery, generate_delete_query, generate_insert_query},
         },
@@ -48,8 +49,13 @@ impl GetPartitionKey for LockerPrimaryKeyType {
         PartitionKey::Locker {
             merchant_id: &self.merchant_id,
             customer_id: &self.customer_id,
-            locker_id: self.locker_id.peek(),
         }
+    }
+}
+
+impl GetSecondaryKey for LockerPrimaryKeyType {
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.locker_id.peek().clone())
     }
 }
 

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -81,10 +81,7 @@ impl GetLookupKey for LockerHashLookupKey {
 impl KvSecondaryLookupResource for Locker {
     type LookupKeyType = LockerHashLookupKey;
 
-    fn get_reverse_lookup_key(
-        new_object: &Self::DieselNew,
-        _partition_key: &PartitionKey<'_>,
-    ) -> Self::LookupKeyType {
+    fn get_reverse_lookup_key(new_object: &Self::DieselNew) -> Self::LookupKeyType {
         LockerHashLookupKey {
             hash_id: new_object.hash_id.clone(),
             customer_id: new_object.customer_id.clone(),

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -9,11 +9,12 @@ use crate::{
         kv::{
             StorageScheme,
             entity::EntityType,
+            impls::reverse_lookup::ReverseLookupPrimaryKey,
             partition_key::{KvStorePartition, PartitionKey},
             resource::{
-                GetLookupKey, GetPartitionKey, GetSecondaryKey, KvDeletableResource,
-                KvDeletableWithLookup, KvResource, KvSecondaryLookupResource, ReverseLookupInsert,
-                ReverseLookupKey, SecondaryKey,
+                GetPartitionKey, GetReverseLookupPrimaryKey, GetSecondaryKey,
+                KvDeletableResource, KvDeletableWithLookup, KvResource,
+                KvSecondaryLookupResource, ReverseLookupInsert, SecondaryKey,
             },
             serializable_query::{SerializableQuery, generate_delete_query, generate_insert_query},
         },
@@ -65,14 +66,14 @@ pub(crate) struct LockerHashLookupKey {
     pub customer_id: String,
 }
 
-impl GetLookupKey for LockerHashLookupKey {
-    fn get_lookup_key(&self) -> ReverseLookupKey {
+impl GetReverseLookupPrimaryKey for LockerHashLookupKey {
+    fn get_reverse_lookup_primary_key(&self) -> ReverseLookupPrimaryKey {
         let Self {
             hash_id,
             merchant_id,
             customer_id,
         } = self;
-        ReverseLookupKey {
+        ReverseLookupPrimaryKey {
             lookup_id: format!("locker_{merchant_id}_{customer_id}_{hash_id}"),
         }
     }
@@ -86,6 +87,14 @@ impl KvSecondaryLookupResource for Locker {
             hash_id: new_object.hash_id.clone(),
             customer_id: new_object.customer_id.clone(),
             merchant_id: new_object.merchant_id.clone(),
+        }
+    }
+
+    fn get_reverse_lookup_key_from_resource(resource: &Self) -> Self::LookupKeyType {
+        LockerHashLookupKey {
+            hash_id: resource.hash_id.clone(),
+            customer_id: resource.customer_id.clone(),
+            merchant_id: resource.merchant_id.clone(),
         }
     }
 
@@ -253,13 +262,4 @@ impl KvDeletableResource for Locker {
     }
 }
 
-impl KvDeletableWithLookup for Locker {
-    fn get_reverse_lookup_key_from_resource(resource: &Self) -> ReverseLookupKey {
-        ReverseLookupKey {
-            lookup_id: format!(
-                "locker_{}_{}_{}",
-                resource.merchant_id, resource.customer_id, resource.hash_id
-            ),
-        }
-    }
-}
+impl KvDeletableWithLookup for Locker {}

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -12,9 +12,9 @@ use crate::{
             impls::reverse_lookup::ReverseLookupPrimaryKey,
             partition_key::{KvStorePartition, PartitionKey},
             resource::{
-                GetPartitionKey, GetReverseLookupPrimaryKey, GetSecondaryKey,
-                KvDeletableResource, KvDeletableWithLookup, KvResource,
-                KvSecondaryLookupResource, ReverseLookupInsert, SecondaryKey,
+                GetPartitionKey, GetReverseLookupPrimaryKey, GetSecondaryKey, KvDeletableResource,
+                KvDeletableWithLookup, KvResource, KvSecondaryLookupResource, ReverseLookupInsert,
+                SecondaryKey,
             },
             serializable_query::{SerializableQuery, generate_delete_query, generate_insert_query},
         },

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -10,7 +10,8 @@ use crate::{
             entity::EntityType,
             partition_key::{KvStorePartition, PartitionKey},
             resource::{
-                self as kv_resource, KvDeletableResource, KvDeleteWithoutLookup, KvResource,
+                self as kv_resource, GetPartitionKey, KvDeletableResource, KvDeleteWithoutLookup,
+                KvResource, SecondaryKey,
             },
             serializable_query::{SerializableQuery, generate_delete_query, generate_insert_query},
         },
@@ -38,6 +39,12 @@ impl crate::storage::kv::resource::GetPartitionKey for ReverseLookupPrimaryKey {
         PartitionKey::ReverseLookup {
             lookup_id: &self.lookup_id,
         }
+    }
+}
+
+impl crate::storage::kv::resource::GetSecondaryKey for ReverseLookupPrimaryKey {
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.get_partition_key().to_string())
     }
 }
 

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -11,8 +11,8 @@ use crate::{
             entity::EntityType,
             partition_key::{KvStorePartition, PartitionKey},
             resource::{
-                DirectInsert, GetPartitionKey, KvDeletableResource, KvDeleteWithoutLookup,
-                KvResource, KvUpdatableResource,
+                DirectInsert, GetPartitionKey, GetSecondaryKey, KvDeletableResource,
+                KvDeleteWithoutLookup, KvResource, KvUpdatableResource, SecondaryKey,
             },
             serializable_query::{
                 SerializableQuery, generate_delete_query, generate_insert_query,
@@ -52,6 +52,12 @@ impl GetPartitionKey for VaultPrimaryKey {
             entity_id: self.entity_id.as_str(),
             vault_id: self.vault_id.as_str(),
         }
+    }
+}
+
+impl GetSecondaryKey for VaultPrimaryKey {
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.get_partition_key().to_string())
     }
 }
 

--- a/src/storage/kv/partition_key.rs
+++ b/src/storage/kv/partition_key.rs
@@ -15,7 +15,6 @@ pub(crate) enum PartitionKey<'a> {
     Locker {
         merchant_id: &'a str,
         customer_id: &'a str,
-        locker_id: &'a str,
     },
     ReverseLookup {
         lookup_id: &'a str,
@@ -43,8 +42,7 @@ impl std::fmt::Display for PartitionKey<'_> {
             Self::Locker {
                 merchant_id,
                 customer_id,
-                locker_id,
-            } => write!(f, "locker_{merchant_id}_{customer_id}_{locker_id}"),
+            } => write!(f, "locker_{merchant_id}_{customer_id}"),
             Self::ReverseLookup { lookup_id } => write!(f, "reverse_lookup_{lookup_id}"),
         }
     }

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -256,21 +256,34 @@ pub(crate) trait KvSecondaryLookupResource:
 }
 
 pub(crate) enum InsertConflictKey {
-    PartitionKey(String),
-    LookupKey(String),
+    PartitionKey {
+        partition_key: String,
+        secondary_key: String,
+    },
+    LookupKey {
+        partition_key: String,
+        secondary_key: String,
+    },
 }
 
 impl InsertConflictKey {
-    fn key(&self) -> &str {
+    fn key(&self) -> String {
         match self {
-            Self::PartitionKey(key) | Self::LookupKey(key) => key,
+            Self::PartitionKey {
+                partition_key,
+                secondary_key,
+            }
+            | Self::LookupKey {
+                partition_key,
+                secondary_key,
+            } => kv_key_context(partition_key, secondary_key),
         }
     }
 
     fn kind(&self) -> &'static str {
         match self {
-            Self::PartitionKey(_) => "partition_key",
-            Self::LookupKey(_) => "lookup_key",
+            Self::PartitionKey { .. } => "partition_key",
+            Self::LookupKey { .. } => "lookup_key",
         }
     }
 }
@@ -300,10 +313,10 @@ where
         let primary_key = M::get_primary_key_from_new_object(diesel_new);
 
         match M::storage_find(store, &primary_key).await {
-            Ok(_) => Ok(Some(InsertConflictKey::PartitionKey(kv_key_context(
-                &partition_key.to_string(),
-                &secondary_key.to_string(),
-            )))),
+            Ok(_) => Ok(Some(InsertConflictKey::PartitionKey {
+                partition_key: partition_key.to_string(),
+                secondary_key: secondary_key.to_string(),
+            })),
             Err(err) if err.get_inner().is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
@@ -324,10 +337,10 @@ where
 
         match M::storage_find(store, &primary_key).await {
             Ok(_) => {
-                return Ok(Some(InsertConflictKey::PartitionKey(kv_key_context(
-                    &partition_key.to_string(),
-                    &secondary_key.to_string(),
-                ))));
+                return Ok(Some(InsertConflictKey::PartitionKey {
+                    partition_key: partition_key.to_string(),
+                    secondary_key: secondary_key.to_string(),
+                }));
             }
             Err(err) if err.get_inner().is_not_found() => {}
             Err(err) => return Err(err),
@@ -339,10 +352,10 @@ where
         let reverse_lookup_secondary_key_str = reverse_lookup_key.get_secondary_key().to_string();
 
         match M::storage_find_by_lookup(store, &lookup_key).await {
-            Ok(_) => Ok(Some(InsertConflictKey::LookupKey(kv_key_context(
-                &reverse_lookup_partition_key_str,
-                &reverse_lookup_secondary_key_str,
-            )))),
+            Ok(_) => Ok(Some(InsertConflictKey::LookupKey {
+                partition_key: reverse_lookup_partition_key_str,
+                secondary_key: reverse_lookup_secondary_key_str,
+            })),
             Err(err) if err.get_inner().is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
@@ -548,7 +561,7 @@ where
                                 conflict_key_type = %conflict_key.kind(),
                                 "PostgreSQL conflict found for KV-enabled insert"
                             );
-                            Err(kv_duplicate_error::<M::Error>(conflict_key.key()))
+                            Err(kv_duplicate_error::<M::Error>(&conflict_key.key()))
                         }
                         None => {
                             crate::logger::debug!(

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -426,6 +426,7 @@ async fn decide_storage_scheme_for_insert_operation<M>(
     store: &Storage,
     diesel_new: &M::DieselNew,
     partition_key: &PartitionKey<'_>,
+    secondary_key: &SecondaryKey,
     reverse_lookup_key: Option<&ReverseLookupKey>,
 ) -> Result<DecidedStorageScheme, ContainerError<M::Error>>
 where
@@ -470,6 +471,7 @@ where
             match decide_insert_scheme_from_kv_state::<M>(
                 kv_backend.clone(),
                 partition_key,
+                secondary_key,
                 reverse_lookup_key,
             )
             .await?
@@ -557,6 +559,7 @@ where
             let redis_decision = decide_insert_scheme_from_kv_state::<M>(
                 kv_backend,
                 partition_key,
+                secondary_key,
                 reverse_lookup_key,
             )
             .await?;
@@ -603,6 +606,7 @@ where
 async fn decide_insert_scheme_from_kv_state<M>(
     kv_backend: KvBackend,
     partition_key: &PartitionKey<'_>,
+    secondary_key: &SecondaryKey,
     reverse_lookup_key: Option<&ReverseLookupKey>,
 ) -> Result<Option<DecidedStorageScheme>, ContainerError<M::Error>>
 where
@@ -619,7 +623,7 @@ where
     );
 
     match kv_backend
-        .find::<M::DieselEntity>(partition_key.clone())
+        .find::<M::DieselEntity>(partition_key.clone(), secondary_key.clone())
         .await
     {
         // A live primary key means the insert is a duplicate.
@@ -675,6 +679,7 @@ where
                 lookup_id: &reverse_lookup_key.lookup_id,
             };
             let reverse_lookup_key_str = reverse_lookup_partition_key.to_string();
+            let reverse_lookup_secondary_key = SecondaryKey::new(reverse_lookup_key_str.clone());
 
             crate::logger::debug!(
                 resource = %M::ENTITY_TYPE,
@@ -684,7 +689,10 @@ where
             );
 
             match kv_backend
-                .find::<types::ReverseLookup>(reverse_lookup_partition_key)
+                .find::<types::ReverseLookup>(
+                    reverse_lookup_partition_key,
+                    reverse_lookup_secondary_key,
+                )
                 .await
             {
                 // A live reverse lookup means another live row owns the logical key.
@@ -760,6 +768,7 @@ where
 async fn decide_storage_scheme_for_mutate_operation<M>(
     store: &Storage,
     partition_key: &PartitionKey<'_>,
+    secondary_key: &SecondaryKey,
 ) -> Result<(DecidedStorageScheme, Option<M::DieselEntity>), ContainerError<M::Error>>
 where
     M: KvResource,
@@ -781,7 +790,7 @@ where
             // With this implementation, Hot keys may never recover out of KV.
             let partition_key_str = partition_key.to_string();
             let result = kv_backend
-                .find::<M::DieselEntity>(partition_key.clone())
+                .find::<M::DieselEntity>(partition_key.clone(), secondary_key.clone())
                 .await;
 
             match result {
@@ -816,11 +825,13 @@ where
 {
     let primary_key = M::get_primary_key_from_new_object(&diesel_new);
     let partition_key = primary_key.get_partition_key();
+    let secondary_key = primary_key.get_secondary_key();
     let reverse_lookup_key = get_reverse_lookup_key(&diesel_new, &partition_key);
     let decided_scheme = decide_storage_scheme_for_insert_operation::<M>(
         store,
         &diesel_new,
         &partition_key,
+        &secondary_key,
         reverse_lookup_key.as_ref(),
     )
     .await?;
@@ -837,7 +848,7 @@ where
             let partition_key_str = partition_key.to_string();
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
-                let secondary_key_str = primary_key.get_secondary_key().to_string();
+                let secondary_key_str = secondary_key.to_string();
                 store
                     .insert_reverse_lookup(types::ReverseLookupNew {
                         lookup_id: lookup_id.clone(),
@@ -854,7 +865,7 @@ where
 
             let diesel_entity = diesel_new.into();
             let reply = kv_backend
-                .insert(partition_key, &diesel_entity, drainer_query)
+                .insert(partition_key, secondary_key, &diesel_entity, drainer_query)
                 .await
                 .map_err(|e| {
                     kv_backend_error::<M::Error>(e.to_redis_failed_response(&partition_key_str))
@@ -894,13 +905,9 @@ pub(crate) async fn insert_resource_with_reverse_lookup<M>(
 where
     M: KvSecondaryLookupResource,
 {
-    insert_resource_inner::<M, _>(
-        store,
-        diesel_new,
-        |new_object, partition_key| {
-            Some(M::get_reverse_lookup_key(new_object, partition_key).get_lookup_key())
-        },
-    )
+    insert_resource_inner::<M, _>(store, diesel_new, |new_object, partition_key| {
+        Some(M::get_reverse_lookup_key(new_object, partition_key).get_lookup_key())
+    })
     .await
     .map(Into::into)
 }
@@ -916,6 +923,7 @@ where
     M: KvResource,
 {
     let key = primary_key.get_partition_key();
+    let secondary_key = primary_key.get_secondary_key();
     let decided_scheme = decide_storage_scheme_for_find_operation(store).await;
     log_storage_scheme_decision(M::ENTITY_TYPE, "find", &decided_scheme);
 
@@ -923,7 +931,9 @@ where
         DecidedStorageScheme::PostgresOnly => M::storage_find(store, &primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
             let key_str = key.to_string();
-            let result = kv_backend.find::<M::DieselEntity>(key.clone()).await;
+            let result = kv_backend
+                .find::<M::DieselEntity>(key.clone(), secondary_key)
+                .await;
 
             match result {
                 Ok(KvFindResult::Present(v)) => Ok(v),
@@ -981,11 +991,17 @@ where
                 lookup_id: &lookup_id.lookup_id,
             };
             let reverse_lookup_key_str = reverse_lookup_partition_key.to_string();
-            let key_str = match kv_backend
-                .find::<types::ReverseLookup>(reverse_lookup_partition_key)
+            let reverse_lookup_secondary_key = SecondaryKey::new(reverse_lookup_key_str.clone());
+            let (partition_key_str, secondary_key_str) = match kv_backend
+                .find::<types::ReverseLookup>(
+                    reverse_lookup_partition_key,
+                    reverse_lookup_secondary_key,
+                )
                 .await
             {
-                Ok(KvFindResult::Present(lookup)) => lookup.get_partition_key().to_string(),
+                Ok(KvFindResult::Present(lookup)) => {
+                    (lookup.get_partition_key().to_string(), lookup.secondary_key)
+                }
                 Ok(KvFindResult::Absent) => {
                     metrics::KV_CACHE_MISS_COUNT.add(
                         1,
@@ -1007,11 +1023,13 @@ where
                     ));
                 }
             };
-
             let result = kv_backend
-                .find::<M::DieselEntity>(PartitionKey::CombinationKey {
-                    combination: &key_str,
-                })
+                .find::<M::DieselEntity>(
+                    PartitionKey::CombinationKey {
+                        combination: &partition_key_str,
+                    },
+                    SecondaryKey::new(secondary_key_str),
+                )
                 .await;
 
             match result {
@@ -1026,10 +1044,10 @@ where
                     M::storage_find_by_lookup(store, &lookup_key).await
                 }
                 Ok(KvFindResult::Deleted) => Err(kv_backend_error::<M::Error>(Report::new(
-                    KvError::ValueNotFound(format!("Data was deleted for key {key_str}")),
+                    KvError::ValueNotFound(format!("Data was deleted for key {partition_key_str}")),
                 ))),
                 Err(e) => Err(kv_backend_error::<M::Error>(
-                    e.to_redis_failed_response(&key_str),
+                    e.to_redis_failed_response(&partition_key_str),
                 )),
             }
         }
@@ -1064,7 +1082,8 @@ where
 {
     let (decided_scheme, cached) = {
         let key = primary_key.get_partition_key();
-        decide_storage_scheme_for_mutate_operation::<M>(store, &key).await?
+        let secondary_key = primary_key.get_secondary_key();
+        decide_storage_scheme_for_mutate_operation::<M>(store, &key, &secondary_key).await?
     };
     log_storage_scheme_decision(M::ENTITY_TYPE, "update", &decided_scheme);
     let scheme = decided_scheme.storage_scheme();
@@ -1074,6 +1093,7 @@ where
         DecidedStorageScheme::PostgresOnly => M::storage_update(store, update, primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
             let key = primary_key.get_partition_key();
+            let secondary_key = primary_key.get_secondary_key();
             let current = match cached {
                 Some(resource) => resource,
                 None => find_resource_by_id_inner::<M>(store, primary_key.clone()).await?,
@@ -1085,7 +1105,7 @@ where
 
             let key_str = key.to_string();
             kv_backend
-                .update(key.clone(), &updated_model, update_query)
+                .update(key.clone(), secondary_key, &updated_model, update_query)
                 .await
                 .map_err(|e| kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_str)))?;
 
@@ -1104,7 +1124,8 @@ where
 {
     let (decided_scheme, _) = {
         let key = primary_key.get_partition_key();
-        decide_storage_scheme_for_mutate_operation::<M>(store, &key).await?
+        let secondary_key = primary_key.get_secondary_key();
+        decide_storage_scheme_for_mutate_operation::<M>(store, &key, &secondary_key).await?
     };
     log_storage_scheme_decision(M::ENTITY_TYPE, "delete", &decided_scheme);
 
@@ -1112,12 +1133,13 @@ where
         DecidedStorageScheme::PostgresOnly => M::storage_delete(store, primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
             let key = primary_key.get_partition_key();
+            let secondary_key = primary_key.get_secondary_key();
             let delete_query = M::generate_delete_drainer_query(&primary_key)
                 .map_err(kv_backend_error::<M::Error>)?;
 
             let key_str = key.to_string();
             kv_backend
-                .delete::<M::DieselEntity>(key.clone(), delete_query)
+                .delete::<M::DieselEntity>(key.clone(), secondary_key, delete_query)
                 .await
                 .map_err(|e| kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_str)))
         }

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -27,8 +27,37 @@ pub(crate) struct ReverseLookupKey {
     pub lookup_id: String,
 }
 
+/// Trait for retrieving the partition key of a KV resource.
+///
+/// This is used to determine which partition a KV resource belongs to.
+///
+/// For redis kv, this would be used to determine the redis stream partition.
 pub(crate) trait GetPartitionKey {
     fn get_partition_key(&self) -> PartitionKey<'_>;
+}
+
+#[derive(Clone, Debug)]
+pub(crate) struct SecondaryKey(String);
+
+impl SecondaryKey {
+    pub(crate) fn new(key: String) -> Self {
+        Self(key)
+    }
+}
+
+impl std::fmt::Display for SecondaryKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+/// Trait for retrieving the secondary key of a KV resource.
+///
+/// This is used to determine which secondary partition a KV resource belongs to.
+///
+/// For redis kv, this would be the hash field key value.
+pub(crate) trait GetSecondaryKey {
+    fn get_secondary_key(&self) -> SecondaryKey;
 }
 
 pub(crate) trait GetLookupKey {
@@ -66,7 +95,7 @@ pub(crate) trait KvResource:
     ///
     /// Use `DirectInsert` when the primary key alone is sufficient for all KV
     /// lookups. Use `ReverseLookupInsert` when inserts must also create a
-    /// secondary-key to primary-key mapping.
+    /// reverse-lookup-key to primary-key mapping.
     type InsertStrategy;
 
     /// Diesel insertable/new-record type used for both Postgres inserts and
@@ -88,7 +117,7 @@ pub(crate) trait KvResource:
     ///
     /// This may be a composite key. It must produce the partition key used by
     /// Redis for primary-key based insert, find, update, and delete operations.
-    type PrimaryKeyType: GetPartitionKey;
+    type PrimaryKeyType: GetPartitionKey + GetSecondaryKey;
 
     /// Reconstruct the primary key from the insert payload for insert-time conflict checks.
     fn get_primary_key_from_new_object(new_object: &Self::DieselNew) -> Self::PrimaryKeyType;
@@ -807,10 +836,13 @@ where
             let partition_key_str = partition_key.to_string();
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
+                let secondary_key_str = M::get_primary_key_from_new_object(&diesel_new)
+                    .get_secondary_key()
+                    .to_string();
                 store
                     .insert_reverse_lookup(types::ReverseLookupNew {
                         lookup_id: lookup_id.clone(),
-                        secondary_key: partition_key_str.clone(),
+                        secondary_key: secondary_key_str,
                         partition_key: partition_key_str.clone(),
                         source: M::ENTITY_TYPE.to_string(),
                         updated_by: scheme.to_string(),

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -807,7 +807,6 @@ where
 async fn insert_resource_inner<M, F>(
     store: &Storage,
     mut diesel_new: M::DieselNew,
-    partition_key: PartitionKey<'_>,
     get_reverse_lookup_key: F,
 ) -> Result<M::DieselEntity, ContainerError<M::Error>>
 where
@@ -815,6 +814,8 @@ where
     M::InsertStrategy: KvInsertConflictStrategy<M>,
     F: FnOnce(&M::DieselNew, &PartitionKey<'_>) -> Option<ReverseLookupKey>,
 {
+    let primary_key = M::get_primary_key_from_new_object(&diesel_new);
+    let partition_key = primary_key.get_partition_key();
     let reverse_lookup_key = get_reverse_lookup_key(&diesel_new, &partition_key);
     let decided_scheme = decide_storage_scheme_for_insert_operation::<M>(
         store,
@@ -836,9 +837,7 @@ where
             let partition_key_str = partition_key.to_string();
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
-                let secondary_key_str = M::get_primary_key_from_new_object(&diesel_new)
-                    .get_secondary_key()
-                    .to_string();
+                let secondary_key_str = primary_key.get_secondary_key().to_string();
                 store
                     .insert_reverse_lookup(types::ReverseLookupNew {
                         lookup_id: lookup_id.clone(),
@@ -874,25 +873,23 @@ where
 /// Insert via KV backend. `AlreadyExists` → `Duplicate`. `PostgresOnly` → `storage_insert`.
 /// On the RedisKv path the model's serial `id` is unresolved (e.g. `0`); the drainer
 /// assigns it on PG replay. Callers only see the business id (`fingerprint_id`).
-#[instrument(skip(store, diesel_new, partition_key), fields(resource = M::ENTITY_TYPE))]
+#[instrument(skip(store, diesel_new), fields(resource = M::ENTITY_TYPE))]
 pub(crate) async fn insert_resource<M>(
     store: &Storage,
     diesel_new: M::DieselNew,
-    partition_key: PartitionKey<'_>,
 ) -> Result<M, ContainerError<M::Error>>
 where
     M: KvResource<InsertStrategy = DirectInsert>,
 {
-    insert_resource_inner::<M, _>(store, diesel_new, partition_key, |_, _| None)
+    insert_resource_inner::<M, _>(store, diesel_new, |_, _| None)
         .await
         .map(Into::into)
 }
 
-#[instrument(skip(store, diesel_new, partition_key), fields(resource = M::ENTITY_TYPE))]
+#[instrument(skip(store, diesel_new), fields(resource = M::ENTITY_TYPE))]
 pub(crate) async fn insert_resource_with_reverse_lookup<M>(
     store: &Storage,
     diesel_new: M::DieselNew,
-    partition_key: PartitionKey<'_>,
 ) -> Result<M, ContainerError<M::Error>>
 where
     M: KvSecondaryLookupResource,
@@ -900,7 +897,6 @@ where
     insert_resource_inner::<M, _>(
         store,
         diesel_new,
-        partition_key,
         |new_object, partition_key| {
             Some(M::get_reverse_lookup_key(new_object, partition_key).get_lookup_key())
         },

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -27,6 +27,18 @@ pub(crate) struct ReverseLookupKey {
     pub lookup_id: String,
 }
 
+impl ReverseLookupKey {
+    fn get_partition_key(&self) -> PartitionKey<'_> {
+        PartitionKey::ReverseLookup {
+            lookup_id: &self.lookup_id,
+        }
+    }
+
+    fn get_secondary_key(&self) -> SecondaryKey {
+        SecondaryKey::new(self.get_partition_key().to_string())
+    }
+}
+
 /// Trait for retrieving the partition key of a KV resource.
 ///
 /// This is used to determine which partition a KV resource belongs to.
@@ -274,6 +286,7 @@ where
         store: &Storage,
         diesel_new: &M::DieselNew,
         partition_key: &PartitionKey<'_>,
+        secondary_key: &SecondaryKey,
     ) -> Result<Option<InsertConflictKey>, ContainerError<M::Error>>;
 }
 
@@ -285,13 +298,15 @@ where
         store: &Storage,
         diesel_new: &M::DieselNew,
         partition_key: &PartitionKey<'_>,
+        secondary_key: &SecondaryKey,
     ) -> Result<Option<InsertConflictKey>, ContainerError<M::Error>> {
         let primary_key = M::get_primary_key_from_new_object(diesel_new);
 
         match M::storage_find(store, &primary_key).await {
-            Ok(_) => Ok(Some(InsertConflictKey::PartitionKey(
-                partition_key.to_string(),
-            ))),
+            Ok(_) => Ok(Some(InsertConflictKey::PartitionKey(kv_key_context(
+                &partition_key.to_string(),
+                &secondary_key.to_string(),
+            )))),
             Err(err) if err.get_inner().is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
@@ -306,14 +321,16 @@ where
         store: &Storage,
         diesel_new: &M::DieselNew,
         partition_key: &PartitionKey<'_>,
+        secondary_key: &SecondaryKey,
     ) -> Result<Option<InsertConflictKey>, ContainerError<M::Error>> {
         let primary_key = M::get_primary_key_from_new_object(diesel_new);
 
         match M::storage_find(store, &primary_key).await {
             Ok(_) => {
-                return Ok(Some(InsertConflictKey::PartitionKey(
-                    partition_key.to_string(),
-                )));
+                return Ok(Some(InsertConflictKey::PartitionKey(kv_key_context(
+                    &partition_key.to_string(),
+                    &secondary_key.to_string(),
+                ))));
             }
             Err(err) if err.get_inner().is_not_found() => {}
             Err(err) => return Err(err),
@@ -321,11 +338,14 @@ where
 
         let lookup_key = M::get_reverse_lookup_key(diesel_new, partition_key);
         let reverse_lookup_key = lookup_key.get_lookup_key();
+        let reverse_lookup_partition_key_str = reverse_lookup_key.get_partition_key().to_string();
+        let reverse_lookup_secondary_key_str = reverse_lookup_key.get_secondary_key().to_string();
 
         match M::storage_find_by_lookup(store, &lookup_key).await {
-            Ok(_) => Ok(Some(InsertConflictKey::LookupKey(
-                reverse_lookup_key.lookup_id,
-            ))),
+            Ok(_) => Ok(Some(InsertConflictKey::LookupKey(kv_key_context(
+                &reverse_lookup_partition_key_str,
+                &reverse_lookup_secondary_key_str,
+            )))),
             Err(err) if err.get_inner().is_not_found() => Ok(None),
             Err(err) => Err(err),
         }
@@ -349,8 +369,12 @@ where
     }))
 }
 
+fn kv_key_context(partition_key: &str, secondary_key: &str) -> String {
+    format!("partition_key={partition_key}, secondary_key={secondary_key}")
+}
+
 fn reverse_lookup_insert_error_to_resource_error<E>(
-    lookup_id: &str,
+    key_context: &str,
     err: ContainerError<ReverseLookupDBError>,
 ) -> ContainerError<E>
 where
@@ -358,7 +382,7 @@ where
 {
     let kv_error = if err.get_inner().is_duplicate() {
         KvError::DuplicateValue {
-            key: lookup_id.to_string(),
+            key: key_context.to_string(),
         }
     } else {
         KvError::Backend
@@ -501,6 +525,7 @@ where
                         store,
                         diesel_new,
                         partition_key,
+                        secondary_key,
                     )
                     .await
                     {
@@ -614,6 +639,8 @@ where
 {
     // Step 1: check the primary Redis key.
     let partition_key_str = partition_key.to_string();
+    let secondary_key_str = secondary_key.to_string();
+    let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
     crate::logger::debug!(
         resource = %M::ENTITY_TYPE,
         operation = "insert",
@@ -635,7 +662,7 @@ where
                 redis_state = "present",
                 "Primary Redis key already exists; treating insert as duplicate"
             );
-            Err(kv_duplicate_error::<M::Error>(&partition_key_str))
+            Err(kv_duplicate_error::<M::Error>(&key_context))
         }
         // A tombstone means a delete may still be draining; re-insert through KV.
         Ok(KvFindResult::Deleted) => {
@@ -675,11 +702,12 @@ where
 
             // Step 3: check the reverse lookup key for resources whose logical insert
             // uniqueness is represented by a secondary Redis key.
-            let reverse_lookup_partition_key = PartitionKey::ReverseLookup {
-                lookup_id: &reverse_lookup_key.lookup_id,
-            };
+            let reverse_lookup_partition_key = reverse_lookup_key.get_partition_key();
             let reverse_lookup_key_str = reverse_lookup_partition_key.to_string();
-            let reverse_lookup_secondary_key = SecondaryKey::new(reverse_lookup_key_str.clone());
+            let reverse_lookup_secondary_key = reverse_lookup_key.get_secondary_key();
+            let reverse_lookup_secondary_key_str = reverse_lookup_secondary_key.to_string();
+            let reverse_lookup_key_context =
+                kv_key_context(&reverse_lookup_key_str, &reverse_lookup_secondary_key_str);
 
             crate::logger::debug!(
                 resource = %M::ENTITY_TYPE,
@@ -704,9 +732,7 @@ where
                         redis_state = "present",
                         "Reverse lookup Redis key already exists; treating insert as duplicate"
                     );
-                    Err(kv_duplicate_error::<M::Error>(
-                        &reverse_lookup_key.lookup_id,
-                    ))
+                    Err(kv_duplicate_error::<M::Error>(&reverse_lookup_key_context))
                 }
                 // A reverse-lookup tombstone is still KV-tracked and should be replaced
                 // through KV rather than bypassed via PostgreSQL.
@@ -744,7 +770,7 @@ where
                         "Reverse lookup Redis state check failed for insert"
                     );
                     Err(kv_backend_error::<M::Error>(
-                        e.to_redis_failed_response(&reverse_lookup_key_str),
+                        e.to_redis_failed_response(&reverse_lookup_key_context),
                     ))
                 }
             }
@@ -758,7 +784,7 @@ where
                 "Primary Redis state check failed for insert"
             );
             Err(kv_backend_error::<M::Error>(
-                e.to_redis_failed_response(&partition_key_str),
+                e.to_redis_failed_response(&key_context),
             ))
         }
     }
@@ -789,6 +815,8 @@ where
             };
             // With this implementation, Hot keys may never recover out of KV.
             let partition_key_str = partition_key.to_string();
+            let secondary_key_str = secondary_key.to_string();
+            let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             let result = kv_backend
                 .find::<M::DieselEntity>(partition_key.clone(), secondary_key.clone())
                 .await;
@@ -806,7 +834,7 @@ where
                     Ok((DecidedStorageScheme::PostgresOnly, None))
                 }
                 Err(e) => Err(kv_backend_error::<M::Error>(
-                    e.to_redis_failed_response(&partition_key_str),
+                    e.to_redis_failed_response(&key_context),
                 )),
             }
         }
@@ -846,9 +874,18 @@ where
                 .map_err(kv_backend_error::<M::Error>)?;
 
             let partition_key_str = partition_key.to_string();
+            let secondary_key_str = secondary_key.to_string();
+            let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
-                let secondary_key_str = secondary_key.to_string();
+                let reverse_lookup_partition_key = reverse_lookup_key.get_partition_key();
+                let reverse_lookup_partition_key_str = reverse_lookup_partition_key.to_string();
+                let reverse_lookup_secondary_key_str =
+                    reverse_lookup_key.get_secondary_key().to_string();
+                let reverse_lookup_key_context = kv_key_context(
+                    &reverse_lookup_partition_key_str,
+                    &reverse_lookup_secondary_key_str,
+                );
                 store
                     .insert_reverse_lookup(types::ReverseLookupNew {
                         lookup_id: lookup_id.clone(),
@@ -859,7 +896,10 @@ where
                     })
                     .await
                     .map_err(|err| {
-                        reverse_lookup_insert_error_to_resource_error::<M::Error>(&lookup_id, err)
+                        reverse_lookup_insert_error_to_resource_error::<M::Error>(
+                            &reverse_lookup_key_context,
+                            err,
+                        )
                     })?;
             }
 
@@ -868,14 +908,12 @@ where
                 .insert(partition_key, secondary_key, &diesel_entity, drainer_query)
                 .await
                 .map_err(|e| {
-                    kv_backend_error::<M::Error>(e.to_redis_failed_response(&partition_key_str))
+                    kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_context))
                 })?;
 
             match reply {
                 KvInsertResult::Inserted => Ok(diesel_entity),
-                KvInsertResult::AlreadyExists => {
-                    Err(kv_duplicate_error::<M::Error>(&partition_key_str))
-                }
+                KvInsertResult::AlreadyExists => Err(kv_duplicate_error::<M::Error>(&key_context)),
             }
         }
     }
@@ -931,8 +969,10 @@ where
         DecidedStorageScheme::PostgresOnly => M::storage_find(store, &primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
             let key_str = key.to_string();
+            let secondary_key_str = secondary_key.to_string();
+            let key_context = kv_key_context(&key_str, &secondary_key_str);
             let result = kv_backend
-                .find::<M::DieselEntity>(key.clone(), secondary_key)
+                .find::<M::DieselEntity>(key.clone(), SecondaryKey::new(secondary_key_str))
                 .await;
 
             match result {
@@ -947,10 +987,10 @@ where
                     M::storage_find(store, &primary_key).await
                 }
                 Ok(KvFindResult::Deleted) => Err(kv_backend_error::<M::Error>(Report::new(
-                    KvError::ValueNotFound(format!("Data was deleted for key {key_str}")),
+                    KvError::ValueNotFound(format!("Data was deleted for key {key_context}")),
                 ))),
                 Err(e) => Err(kv_backend_error::<M::Error>(
-                    e.to_redis_failed_response(&key_str),
+                    e.to_redis_failed_response(&key_context),
                 )),
             }
         }
@@ -987,11 +1027,12 @@ where
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_find_by_lookup(store, &lookup_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
-            let reverse_lookup_partition_key = PartitionKey::ReverseLookup {
-                lookup_id: &lookup_id.lookup_id,
-            };
+            let reverse_lookup_partition_key = lookup_id.get_partition_key();
             let reverse_lookup_key_str = reverse_lookup_partition_key.to_string();
-            let reverse_lookup_secondary_key = SecondaryKey::new(reverse_lookup_key_str.clone());
+            let reverse_lookup_secondary_key = lookup_id.get_secondary_key();
+            let reverse_lookup_secondary_key_str = reverse_lookup_secondary_key.to_string();
+            let reverse_lookup_key_context =
+                kv_key_context(&reverse_lookup_key_str, &reverse_lookup_secondary_key_str);
             let (partition_key_str, secondary_key_str) = match kv_backend
                 .find::<types::ReverseLookup>(
                     reverse_lookup_partition_key,
@@ -1012,17 +1053,17 @@ where
                 Ok(KvFindResult::Deleted) => {
                     return Err(kv_backend_error::<M::Error>(Report::new(
                         KvError::ValueNotFound(format!(
-                            "Data was deleted for reverse lookup key {}",
-                            lookup_id.lookup_id
+                            "Data was deleted for reverse lookup key {reverse_lookup_key_context}",
                         )),
                     )));
                 }
                 Err(err) => {
                     return Err(kv_backend_error::<M::Error>(
-                        err.to_redis_failed_response(&reverse_lookup_key_str),
+                        err.to_redis_failed_response(&reverse_lookup_key_context),
                     ));
                 }
             };
+            let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             let result = kv_backend
                 .find::<M::DieselEntity>(
                     PartitionKey::CombinationKey {
@@ -1044,10 +1085,10 @@ where
                     M::storage_find_by_lookup(store, &lookup_key).await
                 }
                 Ok(KvFindResult::Deleted) => Err(kv_backend_error::<M::Error>(Report::new(
-                    KvError::ValueNotFound(format!("Data was deleted for key {partition_key_str}")),
+                    KvError::ValueNotFound(format!("Data was deleted for key {key_context}")),
                 ))),
                 Err(e) => Err(kv_backend_error::<M::Error>(
-                    e.to_redis_failed_response(&partition_key_str),
+                    e.to_redis_failed_response(&key_context),
                 )),
             }
         }
@@ -1081,9 +1122,10 @@ where
     M::DieselEntity: Clone,
 {
     let (decided_scheme, cached) = {
-        let key = primary_key.get_partition_key();
+        let partition_key = primary_key.get_partition_key();
         let secondary_key = primary_key.get_secondary_key();
-        decide_storage_scheme_for_mutate_operation::<M>(store, &key, &secondary_key).await?
+        decide_storage_scheme_for_mutate_operation::<M>(store, &partition_key, &secondary_key)
+            .await?
     };
     log_storage_scheme_decision(M::ENTITY_TYPE, "update", &decided_scheme);
     let scheme = decided_scheme.storage_scheme();
@@ -1092,7 +1134,7 @@ where
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_update(store, update, primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
-            let key = primary_key.get_partition_key();
+            let partition_key = primary_key.get_partition_key();
             let secondary_key = primary_key.get_secondary_key();
             let current = match cached {
                 Some(resource) => resource,
@@ -1103,11 +1145,20 @@ where
             let updated_model = M::apply_update(update, current);
             let updated_resource = updated_model.clone().into();
 
-            let key_str = key.to_string();
+            let partition_key_str = partition_key.to_string();
+            let secondary_key_str = secondary_key.to_string();
+            let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             kv_backend
-                .update(key.clone(), secondary_key, &updated_model, update_query)
+                .update(
+                    partition_key.clone(),
+                    secondary_key,
+                    &updated_model,
+                    update_query,
+                )
                 .await
-                .map_err(|e| kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_str)))?;
+                .map_err(|e| {
+                    kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_context))
+                })?;
 
             Ok(updated_resource)
         }
@@ -1123,25 +1174,28 @@ where
     M: KvDeletableResource,
 {
     let (decided_scheme, _) = {
-        let key = primary_key.get_partition_key();
+        let partition_key = primary_key.get_partition_key();
         let secondary_key = primary_key.get_secondary_key();
-        decide_storage_scheme_for_mutate_operation::<M>(store, &key, &secondary_key).await?
+        decide_storage_scheme_for_mutate_operation::<M>(store, &partition_key, &secondary_key)
+            .await?
     };
     log_storage_scheme_decision(M::ENTITY_TYPE, "delete", &decided_scheme);
 
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_delete(store, primary_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
-            let key = primary_key.get_partition_key();
+            let partition_key = primary_key.get_partition_key();
             let secondary_key = primary_key.get_secondary_key();
             let delete_query = M::generate_delete_drainer_query(&primary_key)
                 .map_err(kv_backend_error::<M::Error>)?;
 
-            let key_str = key.to_string();
+            let partition_key_str = partition_key.to_string();
+            let secondary_key_str = secondary_key.to_string();
+            let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             kv_backend
-                .delete::<M::DieselEntity>(key.clone(), secondary_key, delete_query)
+                .delete::<M::DieselEntity>(partition_key.clone(), secondary_key, delete_query)
                 .await
-                .map_err(|e| kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_str)))
+                .map_err(|e| kv_backend_error::<M::Error>(e.to_redis_failed_response(&key_context)))
         }
     }
 }

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -8,6 +8,7 @@ use tracing::instrument;
 use super::{
     StorageScheme,
     entity::EntityType,
+    impls::reverse_lookup::ReverseLookupPrimaryKey,
     partition_key::{KvStorePartition, PartitionKey},
     scheme::KvState,
     serializable_query::SerializableQuery,
@@ -21,23 +22,6 @@ use crate::{
     observability::metrics,
     storage::{ReverseLookupInterface, Storage, types},
 };
-
-/// Secondary-to-primary mapping metadata emitted by a KV resource.
-pub(crate) struct ReverseLookupKey {
-    pub lookup_id: String,
-}
-
-impl ReverseLookupKey {
-    fn get_partition_key(&self) -> PartitionKey<'_> {
-        PartitionKey::ReverseLookup {
-            lookup_id: &self.lookup_id,
-        }
-    }
-
-    fn get_secondary_key(&self) -> SecondaryKey {
-        SecondaryKey::new(self.get_partition_key().to_string())
-    }
-}
 
 /// Trait for retrieving the partition key of a KV resource.
 ///
@@ -72,8 +56,8 @@ pub(crate) trait GetSecondaryKey {
     fn get_secondary_key(&self) -> SecondaryKey;
 }
 
-pub(crate) trait GetLookupKey {
-    fn get_lookup_key(&self) -> ReverseLookupKey;
+pub(crate) trait GetReverseLookupPrimaryKey {
+    fn get_reverse_lookup_primary_key(&self) -> ReverseLookupPrimaryKey;
 }
 
 pub(crate) struct DirectInsert;
@@ -186,8 +170,9 @@ pub(crate) trait KvDeletableResource: KvResource {
 
 pub(crate) trait KvDeleteWithoutLookup: KvDeletableResource {}
 
-pub(crate) trait KvDeletableWithLookup: KvDeletableResource {
-    fn get_reverse_lookup_key_from_resource(resource: &Self) -> ReverseLookupKey;
+pub(crate) trait KvDeletableWithLookup:
+    KvDeletableResource + KvSecondaryLookupResource
+{
 }
 
 /// Extension of `KvResource` for resources that support updates by primary key.
@@ -236,7 +221,7 @@ pub(crate) trait KvSecondaryLookupResource:
     KvResource<InsertStrategy = ReverseLookupInsert>
 {
     /// Secondary-key representation used to build and query reverse lookup ids.
-    type LookupKeyType: GetLookupKey;
+    type LookupKeyType: GetReverseLookupPrimaryKey;
 
     /// Derive the secondary lookup key for a newly inserted record.
     ///
@@ -244,6 +229,12 @@ pub(crate) trait KvSecondaryLookupResource:
     /// inserts, allowing later reads by secondary key to resolve the primary
     /// partition key.
     fn get_reverse_lookup_key(new_object: &Self::DieselNew) -> Self::LookupKeyType;
+
+    /// Derive the secondary lookup key from an existing resource.
+    ///
+    /// This is used during deletes to resolve and remove the corresponding
+    /// reverse lookup record.
+    fn get_reverse_lookup_key_from_resource(resource: &Self) -> Self::LookupKeyType;
 
     /// Find a record by secondary key through the backing storage implementation.
     ///
@@ -347,7 +338,7 @@ where
         }
 
         let lookup_key = M::get_reverse_lookup_key(diesel_new);
-        let reverse_lookup_key = lookup_key.get_lookup_key();
+        let reverse_lookup_key = lookup_key.get_reverse_lookup_primary_key();
         let reverse_lookup_partition_key_str = reverse_lookup_key.get_partition_key().to_string();
         let reverse_lookup_secondary_key_str = reverse_lookup_key.get_secondary_key().to_string();
 
@@ -461,7 +452,7 @@ async fn decide_storage_scheme_for_insert_operation<M>(
     diesel_new: &M::DieselNew,
     partition_key: &PartitionKey<'_>,
     secondary_key: &SecondaryKey,
-    reverse_lookup_key: Option<&ReverseLookupKey>,
+    reverse_lookup_key: Option<&ReverseLookupPrimaryKey>,
 ) -> Result<DecidedStorageScheme, ContainerError<M::Error>>
 where
     M: KvResource,
@@ -642,7 +633,7 @@ async fn decide_insert_scheme_from_kv_state<M>(
     kv_backend: KvBackend,
     partition_key: &PartitionKey<'_>,
     secondary_key: &SecondaryKey,
-    reverse_lookup_key: Option<&ReverseLookupKey>,
+    reverse_lookup_key: Option<&ReverseLookupPrimaryKey>,
 ) -> Result<Option<DecidedStorageScheme>, ContainerError<M::Error>>
 where
     M: KvResource,
@@ -859,7 +850,7 @@ async fn insert_resource_inner<M, F>(
 where
     M: KvResource,
     M::InsertStrategy: KvInsertConflictStrategy<M>,
-    F: FnOnce(&M::DieselNew) -> Option<ReverseLookupKey>,
+    F: FnOnce(&M::DieselNew) -> Option<ReverseLookupPrimaryKey>,
 {
     let primary_key = M::get_primary_key_from_new_object(&diesel_new);
     let partition_key = primary_key.get_partition_key();
@@ -888,8 +879,8 @@ where
             let key_context = kv_key_context(&partition_key_str, &secondary_key_str);
             if let Some(reverse_lookup_key) = reverse_lookup_key {
                 let lookup_id = reverse_lookup_key.lookup_id.clone();
-                let reverse_lookup_partition_key = reverse_lookup_key.get_partition_key();
-                let reverse_lookup_partition_key_str = reverse_lookup_partition_key.to_string();
+                let reverse_lookup_partition_key_str =
+                    reverse_lookup_key.get_partition_key().to_string();
                 let reverse_lookup_secondary_key_str =
                     reverse_lookup_key.get_secondary_key().to_string();
                 let reverse_lookup_key_context = kv_key_context(
@@ -954,7 +945,7 @@ where
     M: KvSecondaryLookupResource,
 {
     insert_resource_inner::<M, _>(store, diesel_new, |new_object| {
-        Some(M::get_reverse_lookup_key(new_object).get_lookup_key())
+        Some(M::get_reverse_lookup_key(new_object).get_reverse_lookup_primary_key())
     })
     .await
     .map(Into::into)
@@ -1033,7 +1024,7 @@ where
 {
     let decided_scheme = decide_storage_scheme_for_find_operation(store).await;
     log_storage_scheme_decision(M::ENTITY_TYPE, "find_by_lookup", &decided_scheme);
-    let lookup_id = lookup_key.get_lookup_key();
+    let lookup_id = lookup_key.get_reverse_lookup_primary_key();
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_find_by_lookup(store, &lookup_key).await,
         DecidedStorageScheme::Kv(kv_backend) => {
@@ -1232,7 +1223,9 @@ where
 {
     let reverse_lookup_key = find_optional_resource_by_id::<M>(store, primary_key.clone())
         .await?
-        .map(|resource| M::get_reverse_lookup_key_from_resource(&resource));
+        .map(|resource| {
+            M::get_reverse_lookup_key_from_resource(&resource).get_reverse_lookup_primary_key()
+        });
 
     let deleted_rows = delete_resource_by_id_inner::<M>(store, primary_key).await?;
 

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -243,10 +243,7 @@ pub(crate) trait KvSecondaryLookupResource:
     /// The returned key is persisted as a reverse lookup record during Redis KV
     /// inserts, allowing later reads by secondary key to resolve the primary
     /// partition key.
-    fn get_reverse_lookup_key(
-        new_object: &Self::DieselNew,
-        partition_key: &PartitionKey<'_>,
-    ) -> Self::LookupKeyType;
+    fn get_reverse_lookup_key(new_object: &Self::DieselNew) -> Self::LookupKeyType;
 
     /// Find a record by secondary key through the backing storage implementation.
     ///
@@ -336,7 +333,7 @@ where
             Err(err) => return Err(err),
         }
 
-        let lookup_key = M::get_reverse_lookup_key(diesel_new, partition_key);
+        let lookup_key = M::get_reverse_lookup_key(diesel_new);
         let reverse_lookup_key = lookup_key.get_lookup_key();
         let reverse_lookup_partition_key_str = reverse_lookup_key.get_partition_key().to_string();
         let reverse_lookup_secondary_key_str = reverse_lookup_key.get_secondary_key().to_string();
@@ -849,12 +846,12 @@ async fn insert_resource_inner<M, F>(
 where
     M: KvResource,
     M::InsertStrategy: KvInsertConflictStrategy<M>,
-    F: FnOnce(&M::DieselNew, &PartitionKey<'_>) -> Option<ReverseLookupKey>,
+    F: FnOnce(&M::DieselNew) -> Option<ReverseLookupKey>,
 {
     let primary_key = M::get_primary_key_from_new_object(&diesel_new);
     let partition_key = primary_key.get_partition_key();
     let secondary_key = primary_key.get_secondary_key();
-    let reverse_lookup_key = get_reverse_lookup_key(&diesel_new, &partition_key);
+    let reverse_lookup_key = get_reverse_lookup_key(&diesel_new);
     let decided_scheme = decide_storage_scheme_for_insert_operation::<M>(
         store,
         &diesel_new,
@@ -930,7 +927,7 @@ pub(crate) async fn insert_resource<M>(
 where
     M: KvResource<InsertStrategy = DirectInsert>,
 {
-    insert_resource_inner::<M, _>(store, diesel_new, |_, _| None)
+    insert_resource_inner::<M, _>(store, diesel_new, |_| None)
         .await
         .map(Into::into)
 }
@@ -943,8 +940,8 @@ pub(crate) async fn insert_resource_with_reverse_lookup<M>(
 where
     M: KvSecondaryLookupResource,
 {
-    insert_resource_inner::<M, _>(store, diesel_new, |new_object, partition_key| {
-        Some(M::get_reverse_lookup_key(new_object, partition_key).get_lookup_key())
+    insert_resource_inner::<M, _>(store, diesel_new, |new_object| {
+        Some(M::get_reverse_lookup_key(new_object).get_lookup_key())
     })
     .await
     .map(Into::into)

--- a/src/storage/kv/wrapper.rs
+++ b/src/storage/kv/wrapper.rs
@@ -344,7 +344,11 @@ impl KvBehaviour for KvBackend {
         V: serde::Serialize + Debug + KvStorePartition + Sync,
     {
         match self {
-            Self::Redis(redis) => redis.insert(partition_key, secondary_key, value, query).await,
+            Self::Redis(redis) => {
+                redis
+                    .insert(partition_key, secondary_key, value, query)
+                    .await
+            }
         }
     }
 
@@ -372,7 +376,11 @@ impl KvBehaviour for KvBackend {
         V: serde::Serialize + Debug + KvStorePartition + Sync,
     {
         match self {
-            Self::Redis(redis) => redis.update(partition_key, secondary_key, value, query).await,
+            Self::Redis(redis) => {
+                redis
+                    .update(partition_key, secondary_key, value, query)
+                    .await
+            }
         }
     }
 

--- a/src/storage/kv/wrapper.rs
+++ b/src/storage/kv/wrapper.rs
@@ -7,6 +7,7 @@ use serde::de;
 
 use super::{
     partition_key::{KvStorePartition, PartitionKey},
+    resource::SecondaryKey,
     serializable_query::SerializableQuery,
 };
 use crate::{config::KvConfig, logger, observability::metrics, storage::redis as redis_store};
@@ -119,6 +120,7 @@ pub(crate) trait KvBehaviour {
     async fn insert<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<KvInsertResult, Self::Error>
@@ -128,6 +130,7 @@ pub(crate) trait KvBehaviour {
     async fn find<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
         V: de::DeserializeOwned;
@@ -135,6 +138,7 @@ pub(crate) trait KvBehaviour {
     async fn update<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<(), Self::Error>
@@ -144,6 +148,7 @@ pub(crate) trait KvBehaviour {
     async fn delete<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         query: SerializableQuery,
     ) -> error_stack::Result<usize, Self::Error>
     where
@@ -183,6 +188,7 @@ impl RedisBackend {
     async fn insert_if_absent_or_tombstone(
         &self,
         key: &str,
+        field: &str,
         resource: &str,
         serialized: String,
     ) -> error_stack::Result<KvInsertResult, RedisError> {
@@ -210,7 +216,7 @@ impl RedisBackend {
                 .change_context(RedisError::SetHashFieldFailed)?;
 
             let current = client
-                .hget::<Option<Vec<u8>>, _, _>(redis_key.clone(), key.to_string())
+                .hget::<Option<Vec<u8>>, _, _>(redis_key.clone(), field.to_string())
                 .await
                 .change_context(RedisError::GetHashFieldFailed)?;
 
@@ -251,7 +257,7 @@ impl RedisBackend {
             transaction
                 .hset::<(), _, _>(
                     redis_key.clone(),
-                    vec![(key.to_string(), serialized.clone())],
+                    vec![(field.to_string(), serialized.clone())],
                 )
                 .await
                 .change_context(RedisError::SetHashFieldFailed)?;
@@ -330,6 +336,7 @@ impl KvBehaviour for KvBackend {
     async fn insert<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<KvInsertResult, Self::Error>
@@ -337,25 +344,27 @@ impl KvBehaviour for KvBackend {
         V: serde::Serialize + Debug + KvStorePartition + Sync,
     {
         match self {
-            Self::Redis(redis) => redis.insert(partition_key, value, query).await,
+            Self::Redis(redis) => redis.insert(partition_key, secondary_key, value, query).await,
         }
     }
 
     async fn find<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
         V: de::DeserializeOwned,
     {
         match self {
-            Self::Redis(redis) => redis.find(partition_key).await,
+            Self::Redis(redis) => redis.find(partition_key, secondary_key).await,
         }
     }
 
     async fn update<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<(), Self::Error>
@@ -363,20 +372,21 @@ impl KvBehaviour for KvBackend {
         V: serde::Serialize + Debug + KvStorePartition + Sync,
     {
         match self {
-            Self::Redis(redis) => redis.update(partition_key, value, query).await,
+            Self::Redis(redis) => redis.update(partition_key, secondary_key, value, query).await,
         }
     }
 
     async fn delete<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         query: SerializableQuery,
     ) -> error_stack::Result<usize, Self::Error>
     where
         V: KvStorePartition,
     {
         match self {
-            Self::Redis(redis) => redis.delete::<V>(partition_key, query).await,
+            Self::Redis(redis) => redis.delete::<V>(partition_key, secondary_key, query).await,
         }
     }
 }
@@ -386,6 +396,7 @@ impl KvBehaviour for RedisBackend {
     async fn insert<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<KvInsertResult, Self::Error>
@@ -394,12 +405,13 @@ impl KvBehaviour for RedisBackend {
     {
         with_kv_metrics(KvOperationKind::Insert, async move {
             let key = partition_key.to_string();
+            let field = secondary_key.to_string();
             let resource = query.entity_type();
             let serialized = serde_json::to_string(&KvStoredValue::Value(value))
                 .change_context(RedisError::JsonSerializationFailed)?;
 
             let result = self
-                .insert_if_absent_or_tombstone(&key, &resource, serialized)
+                .insert_if_absent_or_tombstone(&key, &field, &resource, serialized)
                 .await?;
 
             match result {
@@ -419,6 +431,7 @@ impl KvBehaviour for RedisBackend {
     async fn find<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
         V: de::DeserializeOwned,
@@ -426,12 +439,13 @@ impl KvBehaviour for RedisBackend {
         with_kv_metrics(KvOperationKind::Find, async move {
             let redis_conn = self.get_redis_conn();
             let key = partition_key.to_string();
+            let field = secondary_key.to_string();
             let redis_key = key.clone().into();
 
             let stored_value = redis_conn
                 .get_hash_field_and_deserialize::<Option<KvStoredValue<V>>>(
                     &redis_key,
-                    &key,
+                    &field,
                     std::any::type_name::<KvStoredValue<V>>(),
                 )
                 .await
@@ -453,6 +467,7 @@ impl KvBehaviour for RedisBackend {
     async fn update<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         value: &V,
         query: SerializableQuery,
     ) -> error_stack::Result<(), Self::Error>
@@ -462,6 +477,7 @@ impl KvBehaviour for RedisBackend {
         with_kv_metrics(KvOperationKind::Update, async move {
             let redis_conn = self.get_redis_conn();
             let key = partition_key.to_string();
+            let field = secondary_key.to_string();
             let redis_key = key.clone().into();
             let serialized = serde_json::to_string(&KvStoredValue::Value(value))
                 .change_context(RedisError::JsonSerializationFailed)?;
@@ -469,7 +485,7 @@ impl KvBehaviour for RedisBackend {
             redis_conn
                 .set_hash_fields(
                     &redis_key,
-                    vec![(key.as_str(), serialized)],
+                    vec![(field.as_str(), serialized)],
                     Some(self.config.ttl_for_kv.into()),
                 )
                 .await
@@ -484,6 +500,7 @@ impl KvBehaviour for RedisBackend {
     async fn delete<V>(
         &self,
         partition_key: PartitionKey<'_>,
+        secondary_key: SecondaryKey,
         query: SerializableQuery,
     ) -> error_stack::Result<usize, Self::Error>
     where
@@ -492,6 +509,7 @@ impl KvBehaviour for RedisBackend {
         with_kv_metrics(KvOperationKind::Delete, async move {
             let redis_conn = self.get_redis_conn();
             let key = partition_key.to_string();
+            let field = secondary_key.to_string();
             let redis_key = key.clone().into();
             let tombstone =
                 serde_json::to_string(&KvStoredValue::<()>::Tombstone(Self::TOMBSTONE_VALUE))
@@ -500,7 +518,7 @@ impl KvBehaviour for RedisBackend {
             redis_conn
                 .set_hash_fields(
                     &redis_key,
-                    vec![(key.as_str(), tombstone)],
+                    vec![(field.as_str(), tombstone)],
                     Some(self.config.ttl_for_kv.into()),
                 )
                 .await

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -28,18 +28,8 @@ impl VaultInterface for Storage {
     ) -> Result<types::Vault, ContainerError<Self::Error>> {
         #[cfg(feature = "kv")]
         {
-            let vault_id = new.vault_id.peek().clone();
-            let entity_id = new.entity_id.clone();
-            let partition_key = crate::storage::kv::PartitionKey::Vault {
-                entity_id: &entity_id,
-                vault_id: &vault_id,
-            };
             let new_inner = types::VaultNewInner::from(new);
-            return crate::storage::kv::insert_resource::<types::Vault>(
-                self,
-                new_inner,
-                partition_key,
-            )
+            return crate::storage::kv::insert_resource::<types::Vault>(self, new_inner)
             .await;
         }
 

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -29,8 +29,7 @@ impl VaultInterface for Storage {
         #[cfg(feature = "kv")]
         {
             let new_inner = types::VaultNewInner::from(new);
-            return crate::storage::kv::insert_resource::<types::Vault>(self, new_inner)
-            .await;
+            return crate::storage::kv::insert_resource::<types::Vault>(self, new_inner).await;
         }
 
         #[cfg(not(feature = "kv"))]


### PR DESCRIPTION
## Summary
- add `SecondaryKey` support for KV resources and derive it from each resource primary key
- use `PartitionKey` as the Redis hash key and `SecondaryKey` as the Redis hash field key
- derive insert partition/secondary keys internally from `PrimaryKeyType`
- include both partition and secondary keys in KV duplicate/error context

## Testing
- `cargo check --features "release"`
