### PR TITLE
fix(kv): colocate redis keys with drainer streams

### DIFF
--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -129,8 +129,11 @@ ttl_for_kv = 900                   # TTL for KV entries in Redis (seconds)
 
 # Per-tenant `redis_key_prefix` (under `[tenant_secrets.<id>]`) MUST be non-empty
 # and unique across tenants whenever KV is enabled, otherwise the service fails to
-# start.  The drainer must consume the prefixed
-# `{prefix}:{shard_N}_DRAINER_STREAM` for each tenant.
+# start. It must not contain `{` or `}` because KV data keys and drainer streams
+# use `{shard_N}` as the Redis Cluster hash tag. The drainer must consume the
+# prefixed `{prefix}:{shard_N}_DRAINER_STREAM` for each tenant; KV data for that
+# shard is stored under `{prefix}:{shard_N}:<partition-key>` so both keys route to
+# the same Redis Cluster slot.
 
 # Metrics configuration: export metrics for monitoring.
 # - disabled: no metrics exported

--- a/src/config.rs
+++ b/src/config.rs
@@ -387,22 +387,25 @@ impl GlobalConfig {
         Ok(())
     }
 
-    /// Require non-empty, unique `redis_key_prefix` per tenant when kv + redis + multi-tenant.
+    /// Validate `redis_key_prefix` when kv + redis is enabled.
     #[cfg(feature = "kv")]
     fn validate_kv_tenant_prefixes(&self) -> Result<(), error::ConfigurationError> {
         #[cfg(feature = "redis")]
-        if self.redis.is_none() || self.tenant_secrets.len() <= 1 {
+        if self.redis.is_none() {
             return Ok(());
         }
 
         let mut seen: std::collections::HashSet<&str> = std::collections::HashSet::new();
         for (tenant_id, secrets) in self.tenant_secrets.iter() {
             let prefix = secrets.redis_key_prefix.trim();
+            if prefix.contains('{') || prefix.contains('}') {
+                return Err(error::ConfigurationError::InvalidConfigurationValueError(
+                    format!("tenant `{tenant_id}`: redis_key_prefix must not contain `{{` or `}}`"),
+                ));
+            }
             if prefix.is_empty() {
                 return Err(error::ConfigurationError::InvalidConfigurationValueError(
-                    format!(
-                        "tenant `{tenant_id}`: redis_key_prefix required with kv + multi-tenant"
-                    ),
+                    format!("tenant `{tenant_id}`: redis_key_prefix required with kv"),
                 ));
             }
             if !seen.insert(prefix) {
@@ -457,7 +460,8 @@ impl Default for KvConfig {
 
 #[cfg(feature = "kv")]
 impl KvConfig {
-    /// Format: `{shard_key}_{suffix}`.
+    /// Format: `{shard_key}_{suffix}`. The braces are a Redis Cluster hash tag
+    /// and must match the KV data-key hash tag.
     pub fn drainer_stream_name(&self, shard_key: &str) -> String {
         format!("{{{}}}_{}", shard_key, self.drainer_stream_suffix)
     }

--- a/src/storage/kv/partition_key.rs
+++ b/src/storage/kv/partition_key.rs
@@ -1,6 +1,6 @@
 use hyperswitch_masking::{PeekInterface, Secret};
 
-/// Partition key for Redis hash-slot routing and drainer stream derivation.
+/// Partition key for Redis data-key routing and drainer stream derivation.
 #[derive(Clone, Debug)]
 pub(crate) enum PartitionKey<'a> {
     CombinationKey {
@@ -56,5 +56,54 @@ pub(crate) trait KvStorePartition {
 
     fn shard_key(key: PartitionKey<'_>, num_partitions: u8) -> String {
         format!("shard_{}", Self::partition_number(key, num_partitions))
+    }
+
+    fn data_key(key: PartitionKey<'_>, num_partitions: u8) -> String {
+        let partition_key = key.to_string();
+        let shard_key = Self::shard_key(key, num_partitions);
+        format!("{{{shard_key}}}:{partition_key}")
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use fred::util::redis_keyslot;
+
+    use super::{KvStorePartition, PartitionKey};
+    use crate::config::KvConfig;
+
+    struct TestResource;
+
+    impl KvStorePartition for TestResource {}
+
+    #[test]
+    fn data_key_preserves_partition_key_and_adds_hash_tag() {
+        let key = PartitionKey::CombinationKey {
+            combination: "locker_merchant_customer",
+        };
+        let shard_key = TestResource::shard_key(key.clone(), 16);
+
+        assert_eq!(
+            TestResource::data_key(key, 16),
+            format!("{{{shard_key}}}:locker_merchant_customer")
+        );
+    }
+
+    #[test]
+    fn data_key_and_drainer_stream_use_same_redis_cluster_slot() {
+        let key = PartitionKey::CombinationKey {
+            combination: "locker_merchant_customer",
+        };
+        let shard_key = TestResource::shard_key(key.clone(), 16);
+        let data_key = format!("public:{}", TestResource::data_key(key, 16));
+        let stream_name = format!(
+            "public:{}",
+            KvConfig::default().drainer_stream_name(&shard_key)
+        );
+
+        assert_eq!(
+            redis_keyslot(data_key.as_bytes()),
+            redis_keyslot(stream_name.as_bytes())
+        );
     }
 }

--- a/src/storage/kv/wrapper.rs
+++ b/src/storage/kv/wrapper.rs
@@ -133,7 +133,7 @@ pub(crate) trait KvBehaviour {
         secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
-        V: de::DeserializeOwned;
+        V: de::DeserializeOwned + KvStorePartition;
 
     async fn update<V>(
         &self,
@@ -358,7 +358,7 @@ impl KvBehaviour for KvBackend {
         secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
-        V: de::DeserializeOwned,
+        V: de::DeserializeOwned + KvStorePartition,
     {
         match self {
             Self::Redis(redis) => redis.find(partition_key, secondary_key).await,
@@ -412,7 +412,7 @@ impl KvBehaviour for RedisBackend {
         V: serde::Serialize + Debug + KvStorePartition + Sync,
     {
         with_kv_metrics(KvOperationKind::Insert, async move {
-            let key = partition_key.to_string();
+            let key = V::data_key(partition_key.clone(), self.config.drainer_num_partitions);
             let field = secondary_key.to_string();
             let resource = query.entity_type();
             let serialized = serde_json::to_string(&KvStoredValue::Value(value))
@@ -442,11 +442,11 @@ impl KvBehaviour for RedisBackend {
         secondary_key: SecondaryKey,
     ) -> error_stack::Result<KvFindResult<V>, Self::Error>
     where
-        V: de::DeserializeOwned,
+        V: de::DeserializeOwned + KvStorePartition,
     {
         with_kv_metrics(KvOperationKind::Find, async move {
             let redis_conn = self.get_redis_conn();
-            let key = partition_key.to_string();
+            let key = V::data_key(partition_key, self.config.drainer_num_partitions);
             let field = secondary_key.to_string();
             let redis_key = key.clone().into();
 
@@ -484,7 +484,7 @@ impl KvBehaviour for RedisBackend {
     {
         with_kv_metrics(KvOperationKind::Update, async move {
             let redis_conn = self.get_redis_conn();
-            let key = partition_key.to_string();
+            let key = V::data_key(partition_key.clone(), self.config.drainer_num_partitions);
             let field = secondary_key.to_string();
             let redis_key = key.clone().into();
             let serialized = serde_json::to_string(&KvStoredValue::Value(value))
@@ -516,7 +516,7 @@ impl KvBehaviour for RedisBackend {
     {
         with_kv_metrics(KvOperationKind::Delete, async move {
             let redis_conn = self.get_redis_conn();
-            let key = partition_key.to_string();
+            let key = V::data_key(partition_key.clone(), self.config.drainer_num_partitions);
             let field = secondary_key.to_string();
             let redis_key = key.clone().into();
             let tombstone =


### PR DESCRIPTION
## Summary
- store KV Redis data keys under `{shard_N}:<partition-key>` so they share a Redis Cluster slot with `{shard_N}_DRAINER_STREAM`
- require KV Redis tenant prefixes and reject `{` / `}` so prefixes cannot override the shard hash tag
- add Redis keyslot tests and update KV config documentation

## Tests
- `cargo fmt`
- `cargo check --features kv`
- `cargo test --features kv`
- `cargo test --features kv data_key_`

Note: `cargo fmt` prints existing warnings about nightly-only rustfmt options.