### PR TITLE
refactor(storage): migrate from diesel_async/deadpool to diesel/async-bb8-diesel

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,15 +335,15 @@ checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
 name = "async-bb8-diesel"
-version = "0.2.1"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc03a2806f66f36513d65e0a7f34200382230250cadcf8a8397cfbe3f26b795"
+checksum = "433a78c27b116e74d1c773b4b2e76a83cde6dc1e7ca2b65345dcf597d34f16b4"
 dependencies = [
  "async-trait",
  "bb8",
  "diesel",
  "futures",
- "thiserror 1.0.69",
+ "thiserror 2.0.19",
  "tokio",
 ]
 
@@ -921,13 +921,13 @@ checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
 
 [[package]]
 name = "bb8"
-version = "0.8.6"
+version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
+checksum = "457d7ed3f888dfd2c7af56d4975cade43c622f74bdcddfed6d4352f57acc6310"
 dependencies = [
- "async-trait",
  "futures-util",
  "parking_lot",
+ "portable-atomic",
  "tokio",
 ]
 
@@ -1748,6 +1748,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+dependencies = [
+ "darling_core 0.21.3",
+ "darling_macro 0.21.3",
+]
+
+[[package]]
 name = "darling_core"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1776,6 +1786,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "darling_core"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+dependencies = [
+ "fnv",
+ "ident_case",
+ "proc-macro2",
+ "quote",
+ "strsim 0.11.1",
+ "syn 2.0.117",
+]
+
+[[package]]
 name = "darling_macro"
 version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +1817,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core 0.20.10",
+ "quote",
+ "syn 2.0.117",
+]
+
+[[package]]
+name = "darling_macro"
+version = "0.21.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+dependencies = [
+ "darling_core 0.21.3",
  "quote",
  "syn 2.0.117",
 ]
@@ -1918,13 +1953,14 @@ dependencies = [
 
 [[package]]
 name = "diesel"
-version = "2.2.12"
+version = "2.3.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "229850a212cd9b84d4f0290ad9d294afc0ae70fccaa8949dbe8b43ffafa1e20c"
+checksum = "715377c6e464cb44bb89bd8487584240516c8d5052bc645d6babc50bb8be46c3"
 dependencies = [
  "bitflags 2.6.0",
  "byteorder",
  "diesel_derives",
+ "downcast-rs",
  "itoa",
  "pq-sys",
  "r2d2",
@@ -1934,9 +1970,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_derives"
-version = "2.2.3"
+version = "2.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e7f2c3de51e2ba6bf2a648285696137aaf0f5f487bcbea93972fe8a364e131a4"
+checksum = "d1817b7f4279b947fc4cafddec12b0e5f8727141706561ce3ac94a60bddd1cf5"
 dependencies = [
  "diesel_table_macro_syntax",
  "dsl_auto_type",
@@ -1947,9 +1983,9 @@ dependencies = [
 
 [[package]]
 name = "diesel_table_macro_syntax"
-version = "0.2.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "209c735641a413bc68c4923a9d6ad4bcb3ca306b794edaa7eb0b3228a99ffb25"
+checksum = "fe2444076b48641147115697648dc743c2c00b61adade0f01ce67133c7babe8c"
 dependencies = [
  "syn 2.0.117",
 ]
@@ -1993,12 +2029,18 @@ dependencies = [
 ]
 
 [[package]]
-name = "dsl_auto_type"
-version = "0.1.2"
+name = "downcast-rs"
+version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c5d9abe6314103864cc2d8901b7ae224e0ab1a103a0a416661b4097b0779b607"
+checksum = "117240f60069e65410b3ae1bb213295bd828f707b5bec6596a1afc8793ce0cbc"
+
+[[package]]
+name = "dsl_auto_type"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dd122633e4bef06db27737f21d3738fb89c8f6d5360d6d9d7635dda142a7757e"
 dependencies = [
- "darling 0.20.10",
+ "darling 0.21.3",
  "either",
  "heck",
  "proc-macro2",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -334,6 +334,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-bb8-diesel"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc03a2806f66f36513d65e0a7f34200382230250cadcf8a8397cfbe3f26b795"
+dependencies = [
+ "async-trait",
+ "bb8",
+ "diesel",
+ "futures",
+ "thiserror 1.0.69",
+ "tokio",
+]
+
+[[package]]
 name = "async-compression"
 version = "0.4.42"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -904,6 +918,18 @@ name = "base64ct"
 version = "1.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89e25b6adfb930f02d1981565a6e5d9c547ac15a96606256d3b59040e5cd4ca3"
+
+[[package]]
+name = "bb8"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d89aabfae550a5c44b43ab941844ffcd2e993cb6900b342debf59e9ea74acdb8"
+dependencies = [
+ "async-trait",
+ "futures-util",
+ "parking_lot",
+ "tokio",
+]
 
 [[package]]
 name = "bindgen"
@@ -1786,23 +1812,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "deadpool"
-version = "0.12.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6541a3916932fe57768d4be0b1ffb5ec7cbf74ca8c903fdfd5c0fe8aa958f0ed"
-dependencies = [
- "deadpool-runtime",
- "num_cpus",
- "tokio",
-]
-
-[[package]]
-name = "deadpool-runtime"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
-
-[[package]]
 name = "defmt"
 version = "1.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1918,23 +1927,9 @@ dependencies = [
  "diesel_derives",
  "itoa",
  "pq-sys",
+ "r2d2",
  "serde_json",
  "time",
-]
-
-[[package]]
-name = "diesel-async"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb799bb6f8ca6a794462125d7b8983b0c86e6c93a33a9c55934a4a5de4409d3"
-dependencies = [
- "async-trait",
- "deadpool",
- "diesel",
- "futures-util",
- "scoped-futures",
- "tokio",
- "tokio-postgres",
 ]
 
 [[package]]
@@ -2110,12 +2105,6 @@ dependencies = [
  "event-listener",
  "pin-project-lite",
 ]
-
-[[package]]
-name = "fallible-iterator"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4443176a9f2c162692bd3d352d745ef9413eec5782a80d8fd6f8a1ac692a07f7"
 
 [[package]]
 name = "faster-hex"
@@ -2845,7 +2834,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a791e6620676a875f362f3156ed213e73ca099a09bf992c18812abe65cc37b1"
 dependencies = [
  "bstr",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.1",
 ]
 
 [[package]]
@@ -3481,6 +3470,9 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -3805,6 +3797,7 @@ name = "hyperswitch_card_vault"
 version = "0.1.3"
 dependencies = [
  "argh",
+ "async-bb8-diesel",
  "async-trait",
  "aws-config",
  "aws-sdk-kms",
@@ -3812,6 +3805,7 @@ dependencies = [
  "axum-server",
  "axum-test",
  "base64 0.22.1",
+ "bb8",
  "build_info",
  "bytes",
  "config",
@@ -3819,7 +3813,6 @@ dependencies = [
  "crc32fast",
  "criterion",
  "diesel",
- "diesel-async",
  "digest",
  "error-stack 0.4.1",
  "error-stack 0.5.0",
@@ -4353,7 +4346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a2629bb1404f3d34c2e921f21fd34ba00b206124c81f65c50b43b6aaefeb016"
 dependencies = [
  "log",
- "phf 0.10.1",
+ "phf",
  "phf_codegen",
  "string_cache",
  "string_cache_codegen",
@@ -4384,16 +4377,6 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
-]
-
-[[package]]
-name = "md-5"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
-dependencies = [
- "cfg-if",
- "digest",
 ]
 
 [[package]]
@@ -4620,16 +4603,6 @@ checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
  "libm",
-]
-
-[[package]]
-name = "num_cpus"
-version = "1.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
-dependencies = [
- "hermit-abi 0.3.9",
- "libc",
 ]
 
 [[package]]
@@ -5004,15 +4977,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "phf"
-version = "0.11.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ade2d8b8f33c7333b51bcf0428d37e217e9f32192ae4772156f65063b8ce03dc"
-dependencies = [
- "phf_shared 0.11.2",
-]
-
-[[package]]
 name = "phf_codegen"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5199,35 +5163,6 @@ dependencies = [
  "embedded-io 0.6.1",
  "heapless 0.7.17",
  "serde",
-]
-
-[[package]]
-name = "postgres-protocol"
-version = "0.6.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "acda0ebdebc28befa84bee35e651e4c5f09073d668c7aed4cf7e23c3cda84b23"
-dependencies = [
- "base64 0.22.1",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "hmac",
- "md-5",
- "memchr",
- "rand 0.8.5",
- "sha2",
- "stringprep",
-]
-
-[[package]]
-name = "postgres-types"
-version = "0.2.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "02048d9e032fb3cc3413bbf7b83a15d84a5d419778e2628751896d856498eee9"
-dependencies = [
- "bytes",
- "fallible-iterator",
- "postgres-protocol",
 ]
 
 [[package]]
@@ -5542,6 +5477,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
 
 [[package]]
+name = "r2d2"
+version = "0.8.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "51de85fb3fb6524929c8a2eb85e6b6d363de4e8c48f9e2c2eac4944abc181c93"
+dependencies = [
+ "log",
+ "parking_lot",
+ "scheduled-thread-pool",
+]
+
+[[package]]
 name = "radium"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5681,15 +5627,6 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tracing",
-]
-
-[[package]]
-name = "redox_syscall"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4722d768eff46b75989dd134e5c353f0d6296e5aaa3132e776cbdb56be7731aa"
-dependencies = [
- "bitflags 1.3.2",
 ]
 
 [[package]]
@@ -6237,13 +6174,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "scoped-futures"
-version = "0.1.3"
+name = "scheduled-thread-pool"
+version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1473e24c637950c9bd38763220bea91ec3e095a89f672bbd7a10d03e77ba467"
+checksum = "3cbc66816425a074528352f5789333ecff06ca41b36b0b0efdfbb29edc391a19"
 dependencies = [
- "cfg-if",
- "pin-utils",
+ "parking_lot",
 ]
 
 [[package]]
@@ -6595,17 +6531,6 @@ dependencies = [
  "phf_shared 0.11.2",
  "proc-macro2",
  "quote",
-]
-
-[[package]]
-name = "stringprep"
-version = "0.1.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b4df3d392d81bd458a8a621b8bffbd2302a12ffe288a9d931670948749463b1"
-dependencies = [
- "unicode-bidi",
- "unicode-normalization",
- "unicode-properties",
 ]
 
 [[package]]
@@ -7008,32 +6933,6 @@ checksum = "bbae76ab933c85776efabc971569dd6119c580d8f5d448769dec1764bf796ef2"
 dependencies = [
  "native-tls",
  "tokio",
-]
-
-[[package]]
-name = "tokio-postgres"
-version = "0.7.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03adcf0147e203b6032c0b2d30be1415ba03bc348901f3ff1cc0df6a733e60c3"
-dependencies = [
- "async-trait",
- "byteorder",
- "bytes",
- "fallible-iterator",
- "futures-channel",
- "futures-util",
- "log",
- "parking_lot",
- "percent-encoding",
- "phf 0.11.2",
- "pin-project-lite",
- "postgres-protocol",
- "postgres-types",
- "rand 0.8.5",
- "socket2 0.5.7",
- "tokio",
- "tokio-util",
- "whoami",
 ]
 
 [[package]]
@@ -7465,12 +7364,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "unicode-bidi"
-version = "0.3.15"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "08f95100a766bf4f8f28f90d77e0a5461bbdb219042e7679bebe79004fed8d75"
-
-[[package]]
 name = "unicode-bom"
 version = "2.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7490,12 +7383,6 @@ checksum = "a56d1686db2308d901306f92a263857ef59ea39678a5458e7cb17f01415101f5"
 dependencies = [
  "tinyvec",
 ]
-
-[[package]]
-name = "unicode-properties"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52ea75f83c0137a9b98608359a5f1af8144876eb67bcb1ce837368e906a9f524"
 
 [[package]]
 name = "unicode-segmentation"
@@ -7710,12 +7597,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "wasite"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8dad83b4f25e74f184f64c43b150b91efe7647395b42289f38e50566d82855b"
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.125"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7852,17 +7733,6 @@ dependencies = [
  "home",
  "once_cell",
  "rustix 0.38.34",
-]
-
-[[package]]
-name = "whoami"
-version = "1.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a44ab49fad634e88f55bf8f9bb3abd2f27d7204172a112c7c9987e01c1c94ea9"
-dependencies = [
- "redox_syscall 0.4.1",
- "wasite",
- "web-sys",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,9 +48,9 @@ tracing-subscriber = { version = "0.3.18", default-features = true, features = [
 console-subscriber = { version = "0.4.0", optional = true }
 http-body-util = "0.1.2"
 
-diesel = { version = "2.2.10", features = ["postgres", "serde_json", "time", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
-async-bb8-diesel = "0.2.1"
-bb8 = "0.8.6"
+diesel = { version = "2.3.12", features = ["postgres", "serde_json", "time", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
+async-bb8-diesel = "0.3.0"
+bb8 = "0.9.1"
 
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.140"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -48,7 +48,7 @@ tracing-subscriber = { version = "0.3.18", default-features = true, features = [
 console-subscriber = { version = "0.4.0", optional = true }
 http-body-util = "0.1.2"
 
-diesel = { version = "2.2.10", features = ["postgres", "serde_json", "time"] }
+diesel = { version = "2.2.10", features = ["postgres", "serde_json", "time", "i-implement-a-third-party-backend-and-opt-into-breaking-changes"] }
 async-bb8-diesel = "0.2.1"
 bb8 = "0.8.6"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -49,7 +49,8 @@ console-subscriber = { version = "0.4.0", optional = true }
 http-body-util = "0.1.2"
 
 diesel = { version = "2.2.10", features = ["postgres", "serde_json", "time"] }
-diesel-async = { version = "0.5.0", features = ["postgres", "deadpool"] }
+async-bb8-diesel = "0.2.1"
+bb8 = "0.8.6"
 
 serde = { version = "1.0.228", features = ["derive"] }
 serde_json = "1.0.140"

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -22,6 +22,8 @@ password = "damn"  # password of the database
 host = "localhost" # the host where the database is hosted on
 port = 5432        # the port of the database
 dbname = "locker"  # the name of the database where the cards are stored
+# pool_size = 10    # optional: pool size for the database connection pool
+# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled; defaults to 120
 
 # Optional read replica
 # [read_replica]
@@ -31,6 +33,7 @@ dbname = "locker"  # the name of the database where the cards are stored
 # port = 5432        # the port of the read replica database
 # dbname = "locker"  # the name of the read replica database
 # pool_size = 10     # optional: pool size for the read replica connection pool
+# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled; defaults to 120
 
 [secrets]
 locker_private_key = "" # the locker private key to used used and the private key present with the tenant

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -22,8 +22,11 @@ password = "damn"  # password of the database
 host = "localhost" # the host where the database is hosted on
 port = 5432        # the port of the database
 dbname = "locker"  # the name of the database where the cards are stored
-pool_size = 10      # optional: pool size for the database connection pool
-max_lifetime = 120  # optional: max lifetime (in secs) of a pooled connection before it's recycled
+pool_size = 10          # optional: pool size for the database connection pool
+max_lifetime = 120      # optional: max lifetime (in secs) of a pooled connection before it's recycled
+min_idle = 2            # optional: minimum number of idle connections to maintain in the pool
+idle_timeout = 300      # optional: idle timeout (in secs) for a pooled connection
+connection_timeout = 10 # optional: timeout (in secs) for acquiring a connection from the pool
 
 # Optional read replica
 # [read_replica]
@@ -32,8 +35,11 @@ max_lifetime = 120  # optional: max lifetime (in secs) of a pooled connection be
 # host = "localhost" # the host where the read replica is hosted on
 # port = 5432        # the port of the read replica database
 # dbname = "locker"  # the name of the read replica database
-# pool_size = 10     # optional: pool size for the read replica connection pool
-# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled
+# pool_size = 10          # optional: pool size for the read replica connection pool
+# max_lifetime = 120      # optional: max lifetime (in secs) of a pooled connection before it's recycled
+# min_idle = 2            # optional: minimum number of idle connections to maintain in the pool
+# idle_timeout = 300      # optional: idle timeout (in secs) for a pooled connection
+# connection_timeout = 10 # optional: timeout (in secs) for acquiring a connection from the pool
 
 [secrets]
 locker_private_key = "" # the locker private key to used used and the private key present with the tenant

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -22,8 +22,8 @@ password = "damn"  # password of the database
 host = "localhost" # the host where the database is hosted on
 port = 5432        # the port of the database
 dbname = "locker"  # the name of the database where the cards are stored
-# pool_size = 10    # optional: pool size for the database connection pool
-# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled; defaults to 120
+pool_size = 10      # optional: pool size for the database connection pool
+max_lifetime = 120  # optional: max lifetime (in secs) of a pooled connection before it's recycled
 
 # Optional read replica
 # [read_replica]
@@ -33,7 +33,7 @@ dbname = "locker"  # the name of the database where the cards are stored
 # port = 5432        # the port of the read replica database
 # dbname = "locker"  # the name of the read replica database
 # pool_size = 10     # optional: pool size for the read replica connection pool
-# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled; defaults to 120
+# max_lifetime = 120 # optional: max lifetime (in secs) of a pooled connection before it's recycled
 
 [secrets]
 locker_private_key = "" # the locker private key to used used and the private key present with the tenant

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,6 +111,9 @@ pub struct Database {
     pub port: u16,
     pub dbname: String,
     pub pool_size: Option<usize>,
+    /// Maximum lifetime of a pooled connection, in seconds, before it's closed and replaced
+    /// rather than reused. Defaults to 120s if unset.
+    pub max_lifetime: Option<u64>,
 }
 
 #[cfg(feature = "caching")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -110,9 +110,15 @@ pub struct Database {
     pub host: String,
     pub port: u16,
     pub dbname: String,
-    pub pool_size: Option<usize>,
+    pub pool_size: Option<u32>,
     /// Maximum lifetime of a pooled connection, in seconds (default: 120)
     pub max_lifetime: Option<u64>,
+    /// Minimum number of idle connections maintained in the pool (default: 2)
+    pub min_idle: Option<u32>,
+    /// Idle timeout for a pooled connection, in seconds (default: 300)
+    pub idle_timeout: Option<u64>,
+    /// Timeout for acquiring a connection from the pool, in seconds (default: 10)
+    pub connection_timeout: Option<u64>,
 }
 
 #[cfg(feature = "caching")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -111,8 +111,7 @@ pub struct Database {
     pub port: u16,
     pub dbname: String,
     pub pool_size: Option<usize>,
-    /// Maximum lifetime of a pooled connection, in seconds, before it's closed and replaced
-    /// rather than reused. Defaults to 120s if unset.
+    /// Maximum lifetime of a pooled connection, in seconds (default: 120)
     pub max_lifetime: Option<u64>,
 }
 

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -1,3 +1,5 @@
+use crate::logger;
+
 #[derive(Debug, thiserror::Error)]
 pub enum MerchantDBError {
     #[error("Error while encrypting DEK before adding to DB")]
@@ -72,6 +74,7 @@ pub enum TestDBError {
 
 impl From<diesel::result::Error> for TestDBError {
     fn from(err: diesel::result::Error) -> Self {
+        logger::error!(transaction_err=?err, "Error during test-transaction management (begin/commit/rollback)");
         match err {
             diesel::result::Error::DatabaseError(_, _) => Self::DBError,
             _ => Self::UnknownError,

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -70,6 +70,19 @@ pub enum TestDBError {
     DBReplicaNotConfigured,
 }
 
+// Required by `async_bb8_diesel::AsyncConnection::transaction_async`'s `E: From<DieselError>`
+// bound, for errors raised by transaction management itself (begin/commit/rollback) rather than
+// by a query inside the closure — those are mapped per-step via `.map_err` instead, matching
+// hyperswitch's `HealthCheckDBError` (crates/storage_impl/src/errors.rs).
+impl From<diesel::result::Error> for TestDBError {
+    fn from(err: diesel::result::Error) -> Self {
+        match err {
+            diesel::result::Error::DatabaseError(_, _) => Self::DBError,
+            _ => Self::UnknownError,
+        }
+    }
+}
+
 #[derive(Debug, thiserror::Error)]
 pub enum FingerprintDBError {
     #[error("Error while connecting to database")]

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -72,8 +72,7 @@ pub enum TestDBError {
 
 // Required by `async_bb8_diesel::AsyncConnection::transaction_async`'s `E: From<DieselError>`
 // bound, for errors raised by transaction management itself (begin/commit/rollback) rather than
-// by a query inside the closure — those are mapped per-step via `.map_err` instead, matching
-// hyperswitch's `HealthCheckDBError` (crates/storage_impl/src/errors.rs).
+// by a query inside the closure — those are mapped per-step via `.map_err` instead.
 impl From<diesel::result::Error> for TestDBError {
     fn from(err: diesel::result::Error) -> Self {
         match err {

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -70,9 +70,6 @@ pub enum TestDBError {
     DBReplicaNotConfigured,
 }
 
-// Required by `async_bb8_diesel::AsyncConnection::transaction_async`'s `E: From<DieselError>`
-// bound, for errors raised by transaction management itself (begin/commit/rollback) rather than
-// by a query inside the closure — those are mapped per-step via `.map_err` instead.
 impl From<diesel::result::Error> for TestDBError {
     fn from(err: diesel::result::Error) -> Self {
         match err {

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -257,7 +257,6 @@ gauge_metric!(
     name: "database.pool.available",
     description: "Number of available connections in the database pool",
 );
-// Never recorded: bb8 doesn't expose a waiting-callers count like deadpool did.
 gauge_metric!(
     pub(crate) DATABASE_POOL_WAITING, CARD_VAULT_METER,
     name: "database.pool.waiting",

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -257,8 +257,7 @@ gauge_metric!(
     name: "database.pool.available",
     description: "Number of available connections in the database pool",
 );
-// Left registered but never recorded: bb8's `State` (unlike deadpool's `Status`) doesn't expose a
-// count of callers waiting for a connection, so this series is permanently absent from scrapes.
+// Never recorded: bb8 doesn't expose a waiting-callers count like deadpool did.
 gauge_metric!(
     pub(crate) DATABASE_POOL_WAITING, CARD_VAULT_METER,
     name: "database.pool.waiting",

--- a/src/observability/metrics.rs
+++ b/src/observability/metrics.rs
@@ -257,6 +257,8 @@ gauge_metric!(
     name: "database.pool.available",
     description: "Number of available connections in the database pool",
 );
+// Left registered but never recorded: bb8's `State` (unlike deadpool's `Status`) doesn't expose a
+// count of callers waiting for a connection, so this series is permanently absent from scrapes.
 gauge_metric!(
     pub(crate) DATABASE_POOL_WAITING, CARD_VAULT_METER,
     name: "database.pool.waiting",

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -213,7 +213,8 @@ pub struct Storage {
 }
 
 type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
-type PgPooledConn<'a> = bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
+type PgPooledConn<'a> =
+    bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
 
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -301,9 +302,8 @@ impl Storage {
         global_store: Arc<GlobalStore>,
         #[cfg(feature = "redis")] redis: Option<redis_store::TenantAwareRedisStore>,
     ) -> error_stack::Result<Self, error::StorageError> {
-        let pg_pool = Arc::new(
-            Self::create_database_connection_pool(primary_config, schema).await?,
-        );
+        let pg_pool =
+            Arc::new(Self::create_database_connection_pool(primary_config, schema).await?);
 
         let replica_pool = match replica_config {
             Some(config) => Some(Arc::new(
@@ -377,7 +377,9 @@ impl Storage {
 
     /// Returns a connection from the replica pool when the runtime config enables it,
     /// otherwise returns a primary pool connection.
-    pub async fn route_conn(&self) -> Result<DbConnection<'_>, ContainerError<error::StorageError>> {
+    pub async fn route_conn(
+        &self,
+    ) -> Result<DbConnection<'_>, ContainerError<error::StorageError>> {
         if self.should_use_replica() {
             crate::logger::debug!("Routing to read replica");
             self.get_replica_conn().await
@@ -428,9 +430,12 @@ impl Storage {
         if let Some(size) = to_u64(primary.connections as usize, "size", pool, tenant_id) {
             DATABASE_POOL_SIZE.record(size, attrs);
         }
-        if let Some(available) =
-            to_u64(primary.idle_connections as usize, "available", pool, tenant_id)
-        {
+        if let Some(available) = to_u64(
+            primary.idle_connections as usize,
+            "available",
+            pool,
+            tenant_id,
+        ) {
             DATABASE_POOL_AVAILABLE.record(available, attrs);
         }
 
@@ -445,9 +450,12 @@ impl Storage {
             if let Some(size) = to_u64(replica.connections as usize, "size", pool, tenant_id) {
                 DATABASE_POOL_SIZE.record(size, attrs);
             }
-            if let Some(available) =
-                to_u64(replica.idle_connections as usize, "available", pool, tenant_id)
-            {
+            if let Some(available) = to_u64(
+                replica.idle_connections as usize,
+                "available",
+                pool,
+                tenant_id,
+            ) {
                 DATABASE_POOL_AVAILABLE.record(available, attrs);
             }
         }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -213,8 +213,11 @@ pub struct Storage {
 }
 
 type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
-type PgPooledConn<'a> =
-    bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
+
+// The `Deref` target of a checked-out `bb8::PooledConnection`, not the pooled-connection guard
+// itself — the guard borrows the pool it came from (to return the connection on drop), so naming
+// it directly would force that lifetime onto every alias user.
+type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -237,12 +240,15 @@ enum DbOperation {
 crate::impl_metric_value_from!(DbPool, DbOperation);
 
 pub struct DbConnection<'a> {
-    conn: PgPooledConn<'a>,
+    conn: bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>,
     pool: DbPool,
 }
 
 impl<'a> DbConnection<'a> {
-    fn new(conn: PgPooledConn<'a>, pool: DbPool) -> Self {
+    fn new(
+        conn: bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>,
+        pool: DbPool,
+    ) -> Self {
         Self { conn, pool }
     }
 
@@ -253,7 +259,7 @@ impl<'a> DbConnection<'a> {
     // async-bb8-diesel executes queries through `&Connection<PgConnection>` (shared
     // reference, internally mutex-guarded and dispatched to a blocking thread), not
     // through `&mut`, hence the explicit deref instead of a `get_mut`-style accessor.
-    fn get(&self) -> &async_bb8_diesel::Connection<PgConnection> {
+    fn get(&self) -> &PgPooledConn {
         &self.conn
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -219,6 +219,11 @@ type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 // it directly would force that lifetime onto every alias user.
 type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
+// The pooled-connection guard itself, unlike deadpool's `Object<M>` this does borrow the pool
+// it was checked out from, hence the lifetime.
+type PgPooledConnGuard<'a> =
+    bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
+
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
 enum DbPool {
@@ -240,15 +245,12 @@ enum DbOperation {
 crate::impl_metric_value_from!(DbPool, DbOperation);
 
 pub struct DbConnection<'a> {
-    conn: bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>,
+    conn: PgPooledConnGuard<'a>,
     pool: DbPool,
 }
 
 impl<'a> DbConnection<'a> {
-    fn new(
-        conn: bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>,
-        pool: DbPool,
-    ) -> Self {
+    fn new(conn: PgPooledConnGuard<'a>, pool: DbPool) -> Self {
         Self { conn, pool }
     }
 

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -21,13 +21,7 @@ use std::{
     },
 };
 
-use diesel_async::{
-    AsyncPgConnection,
-    pooled_connection::{
-        self,
-        deadpool::{Object, Pool},
-    },
-};
+use diesel::PgConnection;
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
 #[cfg(feature = "kv")]
@@ -208,8 +202,8 @@ impl GlobalStore {
 /// Storage State that is to be passed though the application
 #[derive(Clone)]
 pub struct Storage {
-    primary_pg_pool: Arc<Pool<AsyncPgConnection>>,
-    replica_pg_pool: Option<Arc<Pool<AsyncPgConnection>>>,
+    primary_pg_pool: Arc<PgPool>,
+    replica_pg_pool: Option<Arc<PgPool>>,
     runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
     global_store: Arc<GlobalStore>,
     #[cfg(feature = "redis")]
@@ -218,7 +212,8 @@ pub struct Storage {
     kv_backend: Option<kv::KvBackend>,
 }
 
-type DeadPoolConnType = Object<AsyncPgConnection>;
+type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
+type PgPooledConn<'a> = bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
 
 #[derive(Debug, Clone, Copy, strum::IntoStaticStr)]
 #[strum(serialize_all = "snake_case")]
@@ -240,13 +235,13 @@ enum DbOperation {
 
 crate::impl_metric_value_from!(DbPool, DbOperation);
 
-pub struct DbConnection {
-    conn: DeadPoolConnType,
+pub struct DbConnection<'a> {
+    conn: PgPooledConn<'a>,
     pool: DbPool,
 }
 
-impl DbConnection {
-    fn new(conn: DeadPoolConnType, pool: DbPool) -> Self {
+impl<'a> DbConnection<'a> {
+    fn new(conn: PgPooledConn<'a>, pool: DbPool) -> Self {
         Self { conn, pool }
     }
 
@@ -254,8 +249,11 @@ impl DbConnection {
         self.pool
     }
 
-    fn get_mut(&mut self) -> &mut DeadPoolConnType {
-        &mut self.conn
+    // async-bb8-diesel executes queries through `&Connection<PgConnection>` (shared
+    // reference, internally mutex-guarded and dispatched to a blocking thread), not
+    // through `&mut`, hence the explicit deref instead of a `get_mut`-style accessor.
+    fn get(&self) -> &async_bb8_diesel::Connection<PgConnection> {
+        &*self.conn
     }
 }
 
@@ -264,10 +262,10 @@ impl Storage {
     pub fn get_redis_store(&self) -> Option<redis_store::TenantAwareRedisStore> {
         self.redis.clone()
     }
-    fn create_database_connection_pool(
+    async fn create_database_connection_pool(
         database_config: &Database,
         schema: &str,
-    ) -> error_stack::Result<Pool<AsyncPgConnection>, error::StorageError> {
+    ) -> error_stack::Result<PgPool, error::StorageError> {
         let database_url = format!(
             "postgres://{}:{}@{}:{}/{}?application_name={}&options=-c search_path%3D{}",
             database_config.username,
@@ -279,16 +277,18 @@ impl Storage {
             schema
         );
 
-        let config =
-            pooled_connection::AsyncDieselConnectionManager::<AsyncPgConnection>::new(database_url);
-        let pool = Pool::builder(config);
+        let manager = async_bb8_diesel::ConnectionManager::<PgConnection>::new(database_url);
+        let mut pool = bb8::Pool::builder();
 
-        let pool = match database_config.pool_size {
-            Some(value) => pool.max_size(value),
-            None => pool,
-        };
+        if let Some(value) = database_config.pool_size {
+            let max_size = u32::try_from(value)
+                .change_context(error::StorageError::DBPoolError)
+                .attach_printable("pool_size does not fit in u32")?;
+            pool = pool.max_size(max_size);
+        }
 
-        pool.build()
+        pool.build(manager)
+            .await
             .change_context(error::StorageError::DBPoolError)
     }
 
@@ -301,15 +301,14 @@ impl Storage {
         global_store: Arc<GlobalStore>,
         #[cfg(feature = "redis")] redis: Option<redis_store::TenantAwareRedisStore>,
     ) -> error_stack::Result<Self, error::StorageError> {
-        let pg_pool = Arc::new(Self::create_database_connection_pool(
-            primary_config,
-            schema,
-        )?);
+        let pg_pool = Arc::new(
+            Self::create_database_connection_pool(primary_config, schema).await?,
+        );
 
         let replica_pool = match replica_config {
-            Some(config) => Some(Arc::new(Self::create_database_connection_pool(
-                config, schema,
-            )?)),
+            Some(config) => Some(Arc::new(
+                Self::create_database_connection_pool(config, schema).await?,
+            )),
             None => None,
         };
 
@@ -326,7 +325,7 @@ impl Storage {
     }
 
     /// Get connection from database pool for accessing data
-    pub async fn get_conn(&self) -> Result<DbConnection, ContainerError<error::StorageError>> {
+    pub async fn get_conn(&self) -> Result<DbConnection<'_>, ContainerError<error::StorageError>> {
         let pool = DbPool::Primary;
         let conn = record_db_connection_acquire_duration(self.primary_pg_pool.get(), pool)
             .await
@@ -339,7 +338,7 @@ impl Storage {
     /// Returns `ReplicaPoolNotConfigured` error if no replica pool was initialized.
     pub async fn get_replica_conn(
         &self,
-    ) -> Result<DbConnection, ContainerError<error::StorageError>> {
+    ) -> Result<DbConnection<'_>, ContainerError<error::StorageError>> {
         match self.replica_pg_pool.as_ref() {
             Some(pg_pool) => {
                 let pool = DbPool::Replica;
@@ -378,7 +377,7 @@ impl Storage {
 
     /// Returns a connection from the replica pool when the runtime config enables it,
     /// otherwise returns a primary pool connection.
-    pub async fn route_conn(&self) -> Result<DbConnection, ContainerError<error::StorageError>> {
+    pub async fn route_conn(&self) -> Result<DbConnection<'_>, ContainerError<error::StorageError>> {
         if self.should_use_replica() {
             crate::logger::debug!("Routing to read replica");
             self.get_replica_conn().await
@@ -400,9 +399,7 @@ impl Storage {
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
-        use crate::observability::metrics::{
-            DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE, DATABASE_POOL_WAITING,
-        };
+        use crate::observability::metrics::{DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE};
 
         fn to_u64(value: usize, field: &'static str, pool: DbPool, tenant_id: &str) -> Option<u64> {
             match u64::try_from(value) {
@@ -420,37 +417,38 @@ impl Storage {
             }
         }
 
-        let primary = self.primary_pg_pool.status();
+        // bb8::State only reports `connections`/`idle_connections`; unlike deadpool it does not
+        // expose a count of tasks waiting for a connection, so DATABASE_POOL_WAITING is no longer
+        // populated after this migration.
+        let primary = self.primary_pg_pool.state();
         let pool = DbPool::Primary;
         let attrs =
             metrics_utils::metric_attributes!(("pool", pool), ("tenant_id", tenant_id.to_owned()));
 
-        if let Some(size) = to_u64(primary.size, "size", pool, tenant_id) {
+        if let Some(size) = to_u64(primary.connections as usize, "size", pool, tenant_id) {
             DATABASE_POOL_SIZE.record(size, attrs);
         }
-        if let Some(available) = to_u64(primary.available, "available", pool, tenant_id) {
+        if let Some(available) =
+            to_u64(primary.idle_connections as usize, "available", pool, tenant_id)
+        {
             DATABASE_POOL_AVAILABLE.record(available, attrs);
-        }
-        if let Some(waiting) = to_u64(primary.waiting, "waiting", pool, tenant_id) {
-            DATABASE_POOL_WAITING.record(waiting, attrs);
         }
 
         if let Some(replica) = &self.replica_pg_pool {
-            let replica = replica.status();
+            let replica = replica.state();
             let pool = DbPool::Replica;
             let attrs = metrics_utils::metric_attributes!(
                 ("pool", pool),
                 ("tenant_id", tenant_id.to_owned())
             );
 
-            if let Some(size) = to_u64(replica.size, "size", pool, tenant_id) {
+            if let Some(size) = to_u64(replica.connections as usize, "size", pool, tenant_id) {
                 DATABASE_POOL_SIZE.record(size, attrs);
             }
-            if let Some(available) = to_u64(replica.available, "available", pool, tenant_id) {
+            if let Some(available) =
+                to_u64(replica.idle_connections as usize, "available", pool, tenant_id)
+            {
                 DATABASE_POOL_AVAILABLE.record(available, attrs);
-            }
-            if let Some(waiting) = to_u64(replica.waiting, "waiting", pool, tenant_id) {
-                DATABASE_POOL_WAITING.record(waiting, attrs);
             }
         }
     }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -215,13 +215,8 @@ pub struct Storage {
 
 type PgPool = bb8::Pool<async_bb8_diesel::ConnectionManager<PgConnection>>;
 
-// The `Deref` target of a checked-out `bb8::PooledConnection`, not the pooled-connection guard
-// itself — the guard borrows the pool it came from (to return the connection on drop), so naming
-// it directly would force that lifetime onto every alias user.
 type PgPooledConn = async_bb8_diesel::Connection<PgConnection>;
 
-// The pooled-connection guard itself, unlike deadpool's `Object<M>` this does borrow the pool
-// it was checked out from, hence the lifetime.
 type PgPooledConnGuard<'a> =
     bb8::PooledConnection<'a, async_bb8_diesel::ConnectionManager<PgConnection>>;
 
@@ -259,9 +254,6 @@ impl<'a> DbConnection<'a> {
         self.pool
     }
 
-    // async-bb8-diesel executes queries through `&Connection<PgConnection>` (shared
-    // reference, internally mutex-guarded and dispatched to a blocking thread), not
-    // through `&mut`, hence the explicit deref instead of a `get_mut`-style accessor.
     fn get(&self) -> &PgPooledConn {
         &self.conn
     }
@@ -417,9 +409,6 @@ impl Storage {
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
         use crate::observability::metrics::{DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE};
 
-        // bb8::State reports `connections`/`idle_connections` as `u32`, which always fits `u64`.
-        // Unlike deadpool it does not expose a count of tasks waiting for a connection, so
-        // DATABASE_POOL_WAITING is no longer populated after this migration.
         let primary = self.primary_pg_pool.state();
         let pool = DbPool::Primary;
         let attrs =

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -254,7 +254,7 @@ impl<'a> DbConnection<'a> {
     // reference, internally mutex-guarded and dispatched to a blocking thread), not
     // through `&mut`, hence the explicit deref instead of a `get_mut`-style accessor.
     fn get(&self) -> &async_bb8_diesel::Connection<PgConnection> {
-        &*self.conn
+        &self.conn
     }
 }
 
@@ -403,41 +403,16 @@ impl Storage {
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
         use crate::observability::metrics::{DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE};
 
-        fn to_u64(value: usize, field: &'static str, pool: DbPool, tenant_id: &str) -> Option<u64> {
-            match u64::try_from(value) {
-                Ok(v) => Some(v),
-                Err(_) => {
-                    tracing::warn!(
-                        field,
-                        pool = %<&'static str>::from(pool),
-                        tenant_id,
-                        value,
-                        "Database pool metric value overflows u64, skipping"
-                    );
-                    None
-                }
-            }
-        }
-
-        // bb8::State only reports `connections`/`idle_connections`; unlike deadpool it does not
-        // expose a count of tasks waiting for a connection, so DATABASE_POOL_WAITING is no longer
-        // populated after this migration.
+        // bb8::State reports `connections`/`idle_connections` as `u32`, which always fits `u64`.
+        // Unlike deadpool it does not expose a count of tasks waiting for a connection, so
+        // DATABASE_POOL_WAITING is no longer populated after this migration.
         let primary = self.primary_pg_pool.state();
         let pool = DbPool::Primary;
         let attrs =
             metrics_utils::metric_attributes!(("pool", pool), ("tenant_id", tenant_id.to_owned()));
 
-        if let Some(size) = to_u64(primary.connections as usize, "size", pool, tenant_id) {
-            DATABASE_POOL_SIZE.record(size, attrs);
-        }
-        if let Some(available) = to_u64(
-            primary.idle_connections as usize,
-            "available",
-            pool,
-            tenant_id,
-        ) {
-            DATABASE_POOL_AVAILABLE.record(available, attrs);
-        }
+        DATABASE_POOL_SIZE.record(u64::from(primary.connections), attrs);
+        DATABASE_POOL_AVAILABLE.record(u64::from(primary.idle_connections), attrs);
 
         if let Some(replica) = &self.replica_pg_pool {
             let replica = replica.state();
@@ -447,17 +422,8 @@ impl Storage {
                 ("tenant_id", tenant_id.to_owned())
             );
 
-            if let Some(size) = to_u64(replica.connections as usize, "size", pool, tenant_id) {
-                DATABASE_POOL_SIZE.record(size, attrs);
-            }
-            if let Some(available) = to_u64(
-                replica.idle_connections as usize,
-                "available",
-                pool,
-                tenant_id,
-            ) {
-                DATABASE_POOL_AVAILABLE.record(available, attrs);
-            }
+            DATABASE_POOL_SIZE.record(u64::from(replica.connections), attrs);
+            DATABASE_POOL_AVAILABLE.record(u64::from(replica.idle_connections), attrs);
         }
     }
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -283,16 +283,28 @@ impl Storage {
         let mut pool = bb8::Pool::builder();
 
         if let Some(value) = database_config.pool_size {
-            let max_size = u32::try_from(value)
-                .change_context(error::StorageError::DBPoolError)
-                .attach_printable("pool_size does not fit in u32")?;
-            pool = pool.max_size(max_size);
+            pool = pool.max_size(value);
         }
+
+        let min_idle = database_config
+            .min_idle
+            .unwrap_or(consts::DEFAULT_DB_POOL_MIN_IDLE);
+        pool = pool.min_idle(Some(min_idle));
 
         let max_lifetime = database_config
             .max_lifetime
             .unwrap_or(consts::DEFAULT_DB_POOL_MAX_LIFETIME_SECS);
         pool = pool.max_lifetime(Duration::from_secs(max_lifetime));
+
+        let idle_timeout = database_config
+            .idle_timeout
+            .unwrap_or(consts::DEFAULT_DB_POOL_IDLE_TIMEOUT_SECS);
+        pool = pool.idle_timeout(Duration::from_secs(idle_timeout));
+
+        let connection_timeout = database_config
+            .connection_timeout
+            .unwrap_or(consts::DEFAULT_DB_POOL_CONNECTION_TIMEOUT_SECS);
+        pool = pool.connection_timeout(Duration::from_secs(connection_timeout));
 
         pool.build(manager)
             .await

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -19,6 +19,7 @@ use std::{
         Arc,
         atomic::{AtomicBool, Ordering},
     },
+    time::Duration,
 };
 
 use diesel::PgConnection;
@@ -295,6 +296,11 @@ impl Storage {
                 .attach_printable("pool_size does not fit in u32")?;
             pool = pool.max_size(max_size);
         }
+
+        let max_lifetime = database_config
+            .max_lifetime
+            .unwrap_or(consts::DEFAULT_DB_POOL_MAX_LIFETIME_SECS);
+        pool = pool.max_lifetime(Duration::from_secs(max_lifetime));
 
         pool.build(manager)
             .await

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -419,7 +419,9 @@ impl Storage {
     }
 
     pub fn collect_db_pool_state(&self, tenant_id: &str) {
-        use crate::observability::metrics::{DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE};
+        use crate::observability::metrics::{
+            DATABASE_POOL_AVAILABLE, DATABASE_POOL_SIZE, DATABASE_POOL_WAITING,
+        };
 
         let primary = self.primary_pg_pool.state();
         let pool = DbPool::Primary;
@@ -428,6 +430,7 @@ impl Storage {
 
         DATABASE_POOL_SIZE.record(u64::from(primary.connections), attrs);
         DATABASE_POOL_AVAILABLE.record(u64::from(primary.idle_connections), attrs);
+        DATABASE_POOL_WAITING.record(primary.statistics.pending_gets(), attrs);
 
         if let Some(replica) = &self.replica_pg_pool {
             let replica = replica.state();
@@ -439,6 +442,7 @@ impl Storage {
 
             DATABASE_POOL_SIZE.record(u64::from(replica.connections), attrs);
             DATABASE_POOL_AVAILABLE.record(u64::from(replica.idle_connections), attrs);
+            DATABASE_POOL_WAITING.record(replica.statistics.pending_gets(), attrs);
         }
     }
 }

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -25,6 +25,10 @@ pub const REDIS_HEALTH_CHECK_VALUE: &str = "1";
 #[cfg(feature = "redis")]
 pub const REDIS_HEALTH_CHECK_EXPIRY: i64 = 5;
 
+/// Default maximum lifetime (seconds) of a pooled DB connection when `database.max_lifetime`
+/// is unset
+pub const DEFAULT_DB_POOL_MAX_LIFETIME_SECS: u64 = 120;
+
 /// Header Constants
 pub mod headers {
     pub const CONTENT_TYPE: &str = "Content-Type";

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -25,8 +25,7 @@ pub const REDIS_HEALTH_CHECK_VALUE: &str = "1";
 #[cfg(feature = "redis")]
 pub const REDIS_HEALTH_CHECK_EXPIRY: i64 = 5;
 
-/// Default maximum lifetime (seconds) of a pooled DB connection when `database.max_lifetime`
-/// is unset
+/// Default maximum lifetime (seconds) of a pooled DB connection
 pub const DEFAULT_DB_POOL_MAX_LIFETIME_SECS: u64 = 120;
 
 /// Header Constants

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -27,6 +27,12 @@ pub const REDIS_HEALTH_CHECK_EXPIRY: i64 = 5;
 
 /// Default maximum lifetime (seconds) of a pooled DB connection
 pub const DEFAULT_DB_POOL_MAX_LIFETIME_SECS: u64 = 120;
+/// Default minimum number of idle connections maintained in the DB pool
+pub const DEFAULT_DB_POOL_MIN_IDLE: u32 = 2;
+/// Default idle timeout (seconds) for a pooled DB connection
+pub const DEFAULT_DB_POOL_IDLE_TIMEOUT_SECS: u64 = 300;
+/// Default timeout (seconds) for acquiring a connection from the DB pool
+pub const DEFAULT_DB_POOL_CONNECTION_TIMEOUT_SECS: u64 = 10;
 
 /// Header Constants
 pub mod headers {

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -403,11 +403,7 @@ impl super::TestInterface for Storage {
     async fn test(&self) -> Result<(), ContainerError<Self::Error>> {
         let conn = self.get_conn().await?;
 
-        // diesel_async's `test_transaction` (always-rollback) has no equivalent on
-        // `async_bb8_diesel::AsyncConnection` — its `TestTransaction` customizer instead
-        // pins a whole pool into test-isolation mode at build time, which doesn't fit a
-        // runtime health probe. A plain transaction is behaviorally equivalent here since
-        // the row inserted below is deleted again before commit.
+        // Health probe: insert then delete within one transaction so nothing persists.
         conn.get()
             .transaction_async(|conn| async move {
                 let query = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -407,8 +407,7 @@ impl super::TestInterface for Storage {
         // `async_bb8_diesel::AsyncConnection` — its `TestTransaction` customizer instead
         // pins a whole pool into test-isolation mode at build time, which doesn't fit a
         // runtime health probe. A plain transaction is behaviorally equivalent here since
-        // the row inserted below is deleted again before commit. Per-step error mapping
-        // (read/write/delete) matches hyperswitch's own async-bb8-diesel health check.
+        // the row inserted below is deleted again before commit.
         conn.get()
             .transaction_async(|conn| async move {
                 let query = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -14,6 +14,7 @@ use super::{
 use crate::{
     crypto::encryption_manager::managers::aes,
     error::{self, ContainerError, ResultContainerExt},
+    logger,
     storage::scheme::StorageScheme,
 };
 
@@ -406,11 +407,15 @@ impl super::TestInterface for Storage {
         // `async_bb8_diesel::AsyncConnection` — its `TestTransaction` customizer instead
         // pins a whole pool into test-isolation mode at build time, which doesn't fit a
         // runtime health probe. A plain transaction is behaviorally equivalent here since
-        // the row inserted below is deleted again before commit.
+        // the row inserted below is deleted again before commit. Per-step error mapping
+        // (read/write/delete) matches hyperswitch's own async-bb8-diesel health check.
         conn.get()
             .transaction_async(|conn| async move {
                 let query = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
-                let _x: i32 = query.get_result_async(&conn).await?;
+                let _x: i32 = query.get_result_async(&conn).await.map_err(|err| {
+                    logger::error!(read_err=?err, "Error while reading element in the database");
+                    error::TestDBError::DBReadError
+                })?;
 
                 diesel::insert_into(types::HashTable::table())
                     .values(types::HashTableNew {
@@ -421,19 +426,26 @@ impl super::TestInterface for Storage {
                         updated_by: Some(StorageScheme::PostgresOnly),
                     })
                     .execute_async(&conn)
-                    .await?;
+                    .await
+                    .map_err(|err| {
+                        logger::error!(write_err=?err, "Error while writing to database");
+                        error::TestDBError::DBWriteError
+                    })?;
 
                 diesel::delete(
                     types::HashTable::table()
                         .filter(schema::hash_table::hash_id.eq("test".to_string())),
                 )
                 .execute_async(&conn)
-                .await?;
+                .await
+                .map_err(|err| {
+                    logger::error!(delete_err=?err, "Error while deleting element in the database");
+                    error::TestDBError::DBDeleteError
+                })?;
 
-                Ok::<(), diesel::result::Error>(())
+                Ok::<(), error::TestDBError>(())
             })
-            .await
-            .change_error(error::StorageError::FindError)?;
+            .await?;
 
         Ok(())
     }

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,7 +1,7 @@
+use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
 #[cfg(not(feature = "kv"))]
 use diesel::{BoolExpressionMethods, OptionalExtension};
 use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
-use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::Secret;
@@ -409,8 +409,7 @@ impl super::TestInterface for Storage {
         // the row inserted below is deleted again before commit.
         conn.get()
             .transaction_async(|conn| async move {
-                let query =
-                    diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
+                let query = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
                 let _x: i32 = query.get_result_async(&conn).await?;
 
                 diesel::insert_into(types::HashTable::table())
@@ -566,7 +565,8 @@ impl super::EntityInterface for Storage {
         // A missing row surfaces as `EntityDBError::NotFoundError` (see the `From<diesel>`
         // classifier), which `find_or_create_entity` in the key manager checks via
         // `is_not_found()`.
-        let query = types::Entity::table().filter(schema::entity::entity_id.eq(entity_id.to_owned()));
+        let query =
+            types::Entity::table().filter(schema::entity::entity_id.eq(entity_id.to_owned()));
 
         let pool = conn.pool();
         let operation = DbOperation::FindOne;

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "kv"))]
 use diesel::{BoolExpressionMethods, OptionalExtension};
 use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::{AsyncConnection, RunQueryDsl};
+use async_bb8_diesel::{AsyncConnection, AsyncRunQueryDsl};
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
 use hyperswitch_masking::Secret;
@@ -27,12 +27,12 @@ impl MerchantInterface for Storage {
         key: &aes::GcmAes256,
     ) -> Result<types::Merchant, ContainerError<Self::Error>> {
         // Reads are routed to the read replica when enabled.
-        let mut conn = self.route_conn().await?;
+        let conn = self.route_conn().await?;
 
         // Single SELECT; a missing row surfaces (via `?`) as `MerchantDBError::NotFoundError`.
         // Decryption of the stored DEK is the merchant-specific envelope.
-        let query =
-            types::MerchantInner::table().filter(schema::merchant::merchant_id.eq(merchant_id));
+        let query = types::MerchantInner::table()
+            .filter(schema::merchant::merchant_id.eq(merchant_id.to_owned()));
 
         let pool = conn.pool();
         let operation = DbOperation::FindOne;
@@ -42,7 +42,7 @@ impl MerchantInterface for Storage {
 
         let inner: types::MerchantInner =
             super::record_db_query::<<types::MerchantInner as HasTable>::Table, _, _, _>(
-                query.get_result(conn.get_mut()),
+                query.get_result_async(conn.get()),
                 operation,
                 pool,
             )
@@ -56,7 +56,7 @@ impl MerchantInterface for Storage {
         new: types::MerchantNew<'_>,
         key: &aes::GcmAes256,
     ) -> Result<types::Merchant, ContainerError<Self::Error>> {
-        let mut conn = self.get_conn().await?;
+        let conn = self.get_conn().await?;
 
         let query = diesel::insert_into(types::MerchantInner::table()).values(new.encrypt(key)?);
 
@@ -68,7 +68,7 @@ impl MerchantInterface for Storage {
 
         let inner: types::MerchantInner =
             super::record_db_query::<<types::MerchantInner as HasTable>::Table, _, _, _>(
-                query.get_result(conn.get_mut()),
+                query.get_result_async(conn.get()),
                 operation,
                 pool,
             )
@@ -83,7 +83,7 @@ impl MerchantInterface for Storage {
         key: &Self::Algorithm,
         limit: i64,
     ) -> Result<Vec<types::Merchant>, ContainerError<Self::Error>> {
-        let mut conn = self.route_conn().await?;
+        let conn = self.route_conn().await?;
 
         let query = schema::merchant::table
             .filter(
@@ -100,7 +100,7 @@ impl MerchantInterface for Storage {
 
         let result: Result<Vec<types::MerchantInner>, ContainerError<Self::Error>> =
             super::record_db_query::<<types::MerchantInner as HasTable>::Table, _, _, _>(
-                query.load::<types::MerchantInner>(conn.get_mut()),
+                query.load_async::<types::MerchantInner>(conn.get()),
                 operation,
                 pool,
             )
@@ -134,7 +134,7 @@ impl super::LockerInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = diesel::insert_into(types::LockerInner::table()).values(new);
 
@@ -146,7 +146,7 @@ impl super::LockerInterface for Storage {
 
             let output: types::LockerInner =
                 super::record_db_query::<<types::LockerInner as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -174,14 +174,14 @@ impl super::LockerInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             // A missing row surfaces (via `?`) as `VaultDBError::NotFoundError`.
             let query = types::LockerInner::table().filter(
                 schema::locker::locker_id
                     .eq(locker_id.expose())
-                    .and(schema::locker::merchant_id.eq(merchant_id))
-                    .and(schema::locker::customer_id.eq(customer_id)),
+                    .and(schema::locker::merchant_id.eq(merchant_id.to_owned()))
+                    .and(schema::locker::customer_id.eq(customer_id.to_owned())),
             );
 
             let pool = conn.pool();
@@ -192,7 +192,7 @@ impl super::LockerInterface for Storage {
 
             let output: types::LockerInner =
                 super::record_db_query::<<types::LockerInner as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -224,13 +224,13 @@ impl super::LockerInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = types::LockerInner::table().filter(
                 schema::locker::hash_id
-                    .eq(hash_id)
-                    .and(schema::locker::merchant_id.eq(merchant_id))
-                    .and(schema::locker::customer_id.eq(customer_id)),
+                    .eq(hash_id.to_owned())
+                    .and(schema::locker::merchant_id.eq(merchant_id.to_owned()))
+                    .and(schema::locker::customer_id.eq(customer_id.to_owned())),
             );
 
             let pool = conn.pool();
@@ -247,7 +247,7 @@ impl super::LockerInterface for Storage {
             >(
                 async {
                     query
-                        .get_result::<types::LockerInner>(conn.get_mut())
+                        .get_result_async::<types::LockerInner>(conn.get())
                         .await
                         .optional()
                 },
@@ -280,12 +280,12 @@ impl super::LockerInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             let query = diesel::delete(types::LockerInner::table()).filter(
                 schema::locker::locker_id
                     .eq(locker_id.expose())
-                    .and(schema::locker::merchant_id.eq(merchant_id))
-                    .and(schema::locker::customer_id.eq(customer_id)),
+                    .and(schema::locker::merchant_id.eq(merchant_id.to_owned()))
+                    .and(schema::locker::customer_id.eq(customer_id.to_owned())),
             );
 
             let pool = conn.pool();
@@ -296,7 +296,7 @@ impl super::LockerInterface for Storage {
 
             let output =
                 super::record_db_query_rows::<<types::LockerInner as HasTable>::Table, _, _>(
-                    query.execute(conn.get_mut()),
+                    query.execute_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -322,7 +322,7 @@ impl super::HashInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = types::HashTable::table()
                 .filter(schema::hash_table::data_hash.eq(data_hash.expose()));
@@ -337,7 +337,7 @@ impl super::HashInterface for Storage {
                 super::record_db_query_optional::<<types::HashTable as HasTable>::Table, _, _, _>(
                     async {
                         query
-                            .get_result::<types::HashTable>(conn.get_mut())
+                            .get_result_async::<types::HashTable>(conn.get())
                             .await
                             .optional()
                     },
@@ -367,7 +367,7 @@ impl super::HashInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query =
                 diesel::insert_into(types::HashTable::table()).values(types::HashTableNew {
@@ -385,7 +385,7 @@ impl super::HashInterface for Storage {
 
             let output: types::HashTable =
                 super::record_db_query::<<types::HashTable as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -400,53 +400,51 @@ impl super::TestInterface for Storage {
     type Error = error::TestDBError;
 
     async fn test(&self) -> Result<(), ContainerError<Self::Error>> {
-        let mut conn = self.get_conn().await?;
+        let conn = self.get_conn().await?;
 
-        let _data = conn
-            .get_mut()
-            .test_transaction(|x| {
-                Box::pin(async {
-                    let query =
-                        diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
-                    let _x: i32 = query
-                        .get_result(x)
-                        .await
-                        .change_error(error::StorageError::FindError)?;
+        // diesel_async's `test_transaction` (always-rollback) has no equivalent on
+        // `async_bb8_diesel::AsyncConnection` — its `TestTransaction` customizer instead
+        // pins a whole pool into test-isolation mode at build time, which doesn't fit a
+        // runtime health probe. A plain transaction is behaviorally equivalent here since
+        // the row inserted below is deleted again before commit.
+        conn.get()
+            .transaction_async(|conn| async move {
+                let query =
+                    diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
+                let _x: i32 = query.get_result_async(&conn).await?;
 
-                    diesel::insert_into(types::HashTable::table())
-                        .values(types::HashTableNew {
-                            hash_id: "test".to_string(),
-                            data_hash: Secret::new(b"0".to_vec()),
-                            created_at: crate::utils::date_time::now(),
-                            // Test-only — always PostgresOnly.
-                            updated_by: Some(StorageScheme::PostgresOnly),
-                        })
-                        .execute(x)
-                        .await
-                        .change_error(error::StorageError::InsertError)?;
+                diesel::insert_into(types::HashTable::table())
+                    .values(types::HashTableNew {
+                        hash_id: "test".to_string(),
+                        data_hash: Secret::new(b"0".to_vec()),
+                        created_at: crate::utils::date_time::now(),
+                        // Test-only — always PostgresOnly.
+                        updated_by: Some(StorageScheme::PostgresOnly),
+                    })
+                    .execute_async(&conn)
+                    .await?;
 
-                    diesel::delete(
-                        types::HashTable::table()
-                            .filter(schema::hash_table::hash_id.eq("test".to_string())),
-                    )
-                    .execute(x)
-                    .await
-                    .change_error(error::StorageError::DeleteError)?;
+                diesel::delete(
+                    types::HashTable::table()
+                        .filter(schema::hash_table::hash_id.eq("test".to_string())),
+                )
+                .execute_async(&conn)
+                .await?;
 
-                    Ok::<_, ContainerError<Self::Error>>(())
-                })
+                Ok::<(), diesel::result::Error>(())
             })
-            .await;
+            .await
+            .change_error(error::StorageError::FindError)?;
 
         Ok(())
     }
 
     async fn test_replica(&self) -> Result<(), ContainerError<Self::Error>> {
-        let mut conn = self.get_replica_conn().await?;
+        let conn = self.get_replica_conn().await?;
 
         let query = diesel::select(diesel::dsl::sql::<diesel::sql_types::Integer>("1 + 1"));
         let _x: i32 = query
-            .get_result(conn.get_mut())
+            .get_result_async(conn.get())
             .await
             .change_error(error::StorageError::FindError)?;
 
@@ -473,7 +471,7 @@ impl super::FingerprintInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = types::Fingerprint::table()
                 .filter(schema::fingerprint::fingerprint_hash.eq(fingerprint_hash.expose()));
@@ -492,7 +490,7 @@ impl super::FingerprintInterface for Storage {
             >(
                 async {
                     query
-                        .get_result::<types::Fingerprint>(conn.get_mut())
+                        .get_result_async::<types::Fingerprint>(conn.get())
                         .await
                         .optional()
                 },
@@ -525,7 +523,7 @@ impl super::FingerprintInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = diesel::insert_into(types::Fingerprint::table()).values(
                 types::FingerprintTableNew {
@@ -543,7 +541,7 @@ impl super::FingerprintInterface for Storage {
 
             let output: types::Fingerprint =
                 super::record_db_query::<<types::Fingerprint as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -563,12 +561,12 @@ impl super::EntityInterface for Storage {
         entity_id: &str,
     ) -> Result<types::Entity, ContainerError<Self::Error>> {
         // Reads are routed to the read replica when enabled.
-        let mut conn = self.route_conn().await?;
+        let conn = self.route_conn().await?;
 
         // A missing row surfaces as `EntityDBError::NotFoundError` (see the `From<diesel>`
         // classifier), which `find_or_create_entity` in the key manager checks via
         // `is_not_found()`.
-        let query = types::Entity::table().filter(schema::entity::entity_id.eq(entity_id));
+        let query = types::Entity::table().filter(schema::entity::entity_id.eq(entity_id.to_owned()));
 
         let pool = conn.pool();
         let operation = DbOperation::FindOne;
@@ -579,7 +577,7 @@ impl super::EntityInterface for Storage {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
 
         Ok(output)
@@ -590,7 +588,7 @@ impl super::EntityInterface for Storage {
         entity_id: &str,
         identifier: &str,
     ) -> Result<types::Entity, ContainerError<Self::Error>> {
-        let mut conn = self.get_conn().await?;
+        let conn = self.get_conn().await?;
 
         let query = diesel::insert_into(types::Entity::table()).values(types::EntityTableNew {
             entity_id: entity_id.into(),
@@ -606,7 +604,7 @@ impl super::EntityInterface for Storage {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
 
         Ok(output)
@@ -630,7 +628,7 @@ impl super::ReverseLookupInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
 
             let query = diesel::insert_into(types::ReverseLookup::table()).values(new);
 
@@ -645,7 +643,7 @@ impl super::ReverseLookupInterface for Storage {
                 _,
                 _,
                 _,
-            >(query.get_result(conn.get_mut()), operation, pool)
+            >(query.get_result_async(conn.get()), operation, pool)
             .await?;
             Ok(reverse_lookup)
         }
@@ -668,9 +666,9 @@ impl super::ReverseLookupInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             let query = diesel::delete(types::ReverseLookup::table())
-                .filter(schema::reverse_lookup::lookup_id.eq(lookup_id));
+                .filter(schema::reverse_lookup::lookup_id.eq(lookup_id.to_owned()));
 
             let pool = conn.pool();
             let operation = DbOperation::Delete;
@@ -682,7 +680,7 @@ impl super::ReverseLookupInterface for Storage {
                 <types::ReverseLookup as HasTable>::Table,
                 _,
                 _,
-            >(query.execute(conn.get_mut()), operation, pool)
+            >(query.execute_async(conn.get()), operation, pool)
             .await?;
             Ok(output)
         }

--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -1,7 +1,7 @@
 //! KV trait impls for the fingerprint table.
 
 use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use hyperswitch_masking::{PeekInterface, Secret};
 
 use crate::{
@@ -80,7 +80,7 @@ impl KvResource for Fingerprint {
         store: &Storage,
     ) -> Result<Self::DieselEntity, ContainerError<FingerprintDBError>> {
         // Writes always go to the primary pool, never a read replica.
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::insert_into(Self::table()).values(new_object);
 
@@ -89,7 +89,7 @@ impl KvResource for Fingerprint {
         crate::storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output: Self = crate::storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )
@@ -102,10 +102,10 @@ impl KvResource for Fingerprint {
         pk: &Self::PrimaryKeyType,
     ) -> Result<Self::DieselEntity, ContainerError<FingerprintDBError>> {
         // Read path: route to the read replica when runtime config enables it.
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
         let query = Self::table().filter(
             crate::storage::schema::fingerprint::fingerprint_hash
-                .eq(pk.fingerprint_hash.peek().as_slice()),
+                .eq(pk.fingerprint_hash.peek().clone()),
         );
 
         let pool = conn.pool();
@@ -113,7 +113,7 @@ impl KvResource for Fingerprint {
         crate::storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output: Self = crate::storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )

--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -1,7 +1,7 @@
 //! KV trait impls for the fingerprint table.
 
-use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use hyperswitch_masking::{PeekInterface, Secret};
 
 use crate::{

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -1,5 +1,5 @@
 use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use hyperswitch_masking::Secret;
 
 use crate::{
@@ -76,7 +76,7 @@ impl KvResource for HashTable {
         new_object: Self::DieselNew,
         store: &Storage,
     ) -> Result<Self, ContainerError<HashDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::insert_into(Self::table()).values(new_object);
 
@@ -85,7 +85,7 @@ impl KvResource for HashTable {
         crate::storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output: Self = crate::storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )
@@ -97,17 +97,17 @@ impl KvResource for HashTable {
         store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> Result<Self, ContainerError<HashDBError>> {
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
 
-        let query =
-            Self::table().filter(crate::storage::schema::hash_table::data_hash.eq(&pk.data_hash));
+        let query = Self::table()
+            .filter(crate::storage::schema::hash_table::data_hash.eq(pk.data_hash.clone()));
 
         let pool = conn.pool();
         let operation = DbOperation::FindOne;
         crate::storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output: Self = crate::storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -1,5 +1,5 @@
-use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use hyperswitch_masking::Secret;
 
 use crate::{

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -1,5 +1,5 @@
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use hyperswitch_masking::PeekInterface;
 
 use crate::{
@@ -102,16 +102,14 @@ impl KvSecondaryLookupResource for Locker {
         store: &Storage,
         lookup_key: &Self::LookupKeyType,
     ) -> Result<Self, ContainerError<VaultDBError>> {
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
 
         let query = crate::storage::schema::locker::table.filter(
             crate::storage::schema::locker::hash_id
-                .eq(lookup_key.hash_id.as_str())
+                .eq(lookup_key.hash_id.clone())
+                .and(crate::storage::schema::locker::merchant_id.eq(lookup_key.merchant_id.clone()))
                 .and(
-                    crate::storage::schema::locker::merchant_id.eq(lookup_key.merchant_id.as_str()),
-                )
-                .and(
-                    crate::storage::schema::locker::customer_id.eq(lookup_key.customer_id.as_str()),
+                    crate::storage::schema::locker::customer_id.eq(lookup_key.customer_id.clone()),
                 ),
         );
 
@@ -126,7 +124,7 @@ impl KvSecondaryLookupResource for Locker {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
 
         Ok(output.into())
@@ -166,7 +164,7 @@ impl KvResource for Locker {
         new_object: Self::DieselNew,
         store: &Storage,
     ) -> Result<Self::DieselEntity, ContainerError<VaultDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::insert_into(crate::storage::schema::locker::table).values(new_object);
 
@@ -181,7 +179,7 @@ impl KvResource for Locker {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
 
         Ok(output)
@@ -191,13 +189,13 @@ impl KvResource for Locker {
         store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> Result<Self::DieselEntity, ContainerError<VaultDBError>> {
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
 
         let query = crate::storage::schema::locker::table.filter(
             crate::storage::schema::locker::locker_id
-                .eq(pk.locker_id.peek().as_str())
-                .and(crate::storage::schema::locker::merchant_id.eq(pk.merchant_id.as_str()))
-                .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id.as_str())),
+                .eq(pk.locker_id.peek().clone())
+                .and(crate::storage::schema::locker::merchant_id.eq(pk.merchant_id.clone()))
+                .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id.clone())),
         );
 
         let pool = conn.pool();
@@ -211,7 +209,7 @@ impl KvResource for Locker {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
 
         Ok(output)
@@ -236,13 +234,13 @@ impl KvDeletableResource for Locker {
         store: &Storage,
         pk: Self::PrimaryKeyType,
     ) -> Result<usize, ContainerError<VaultDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::delete(LockerInner::table()).filter(
             crate::storage::schema::locker::locker_id
-                .eq(pk.locker_id.peek().as_str())
-                .and(crate::storage::schema::locker::merchant_id.eq(pk.merchant_id.as_str()))
-                .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id.as_str())),
+                .eq(pk.locker_id.peek().clone())
+                .and(crate::storage::schema::locker::merchant_id.eq(pk.merchant_id))
+                .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id)),
         );
 
         let pool = conn.pool();
@@ -253,7 +251,7 @@ impl KvDeletableResource for Locker {
 
         let output =
             crate::storage::record_db_query_rows::<<LockerInner as HasTable>::Table, _, _>(
-                query.execute(conn.get_mut()),
+                query.execute_async(conn.get()),
                 operation,
                 pool,
             )

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -1,5 +1,5 @@
-use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use hyperswitch_masking::PeekInterface;
 
 use crate::{

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -1,5 +1,5 @@
 use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 
 use crate::{
     error::{ContainerError, ReverseLookupDBError, kv::KvError},
@@ -81,7 +81,7 @@ impl KvResource for ReverseLookup {
         new_object: Self::DieselNew,
         store: &Storage,
     ) -> Result<Self, ContainerError<ReverseLookupDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::insert_into(Self::table()).values(new_object);
 
@@ -90,7 +90,7 @@ impl KvResource for ReverseLookup {
         storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let reverse_lookup = storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )
@@ -101,16 +101,16 @@ impl KvResource for ReverseLookup {
         store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> Result<Self, ContainerError<ReverseLookupDBError>> {
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
         let query =
-            Self::table().filter(schema::reverse_lookup::lookup_id.eq(pk.lookup_id.as_str()));
+            Self::table().filter(schema::reverse_lookup::lookup_id.eq(pk.lookup_id.clone()));
 
         let pool = conn.pool();
         let operation = storage::DbOperation::FindOne;
         storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output: Self = storage::record_db_query::<<Self as HasTable>::Table, _, _, _>(
-            query.get_result(conn.get_mut()),
+            query.get_result_async(conn.get()),
             operation,
             pool,
         )
@@ -133,7 +133,7 @@ impl KvDeletableResource for ReverseLookup {
         store: &Storage,
         pk: Self::PrimaryKeyType,
     ) -> Result<usize, ContainerError<ReverseLookupDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::delete(Self::table())
             .filter(crate::storage::schema::reverse_lookup::lookup_id.eq(pk.lookup_id));
@@ -143,7 +143,7 @@ impl KvDeletableResource for ReverseLookup {
         crate::storage::log_db_query::<<Self as HasTable>::Table, _>(&query, operation, pool);
 
         let output = crate::storage::record_db_query_rows::<<Self as HasTable>::Table, _, _>(
-            query.execute(conn.get_mut()),
+            query.execute_async(conn.get()),
             operation,
             pool,
         )

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -1,5 +1,5 @@
-use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 
 use crate::{
     error::{ContainerError, ReverseLookupDBError, kv::KvError},

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -1,5 +1,5 @@
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 use hyperswitch_masking::PeekInterface;
 
 use crate::{
@@ -93,7 +93,7 @@ impl KvResource for Vault {
         new_object: Self::DieselNew,
         store: &Storage,
     ) -> Result<Self::DieselEntity, ContainerError<VaultDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
         let query = diesel::insert_into(VaultInner::table()).values(new_object);
 
         let pool = conn.pool();
@@ -105,7 +105,7 @@ impl KvResource for Vault {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
         Ok(output)
     }
@@ -113,12 +113,12 @@ impl KvResource for Vault {
         store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> Result<Self::DieselEntity, ContainerError<VaultDBError>> {
-        let mut conn = store.route_conn().await?;
+        let conn = store.route_conn().await?;
         // A missing row surfaces (via `?`) as `VaultDBError::NotFoundError`.
         let query = VaultInner::table().filter(
             schema::vault::vault_id
-                .eq(pk.vault_id.as_str())
-                .and(schema::vault::entity_id.eq(pk.entity_id.as_str())),
+                .eq(pk.vault_id.clone())
+                .and(schema::vault::entity_id.eq(pk.entity_id.clone())),
         );
 
         let pool = conn.pool();
@@ -130,7 +130,7 @@ impl KvResource for Vault {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
         Ok(output)
     }
@@ -153,11 +153,11 @@ impl KvDeletableResource for Vault {
         store: &Storage,
         pk: Self::PrimaryKeyType,
     ) -> Result<usize, ContainerError<VaultDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
         let query = diesel::delete(VaultInner::table()).filter(
             schema::vault::vault_id
-                .eq(pk.vault_id.as_str())
-                .and(schema::vault::entity_id.eq(pk.entity_id.as_str())),
+                .eq(pk.vault_id)
+                .and(schema::vault::entity_id.eq(pk.entity_id)),
         );
 
         let pool = conn.pool();
@@ -165,7 +165,7 @@ impl KvDeletableResource for Vault {
         crate::storage::log_db_query::<<VaultInner as HasTable>::Table, _>(&query, operation, pool);
 
         let output = crate::storage::record_db_query_rows::<<VaultInner as HasTable>::Table, _, _>(
-            query.execute(conn.get_mut()),
+            query.execute_async(conn.get()),
             operation,
             pool,
         )
@@ -207,13 +207,13 @@ impl KvUpdatableResource for Vault {
         update: Self::DieselUpdate,
         pk: Self::PrimaryKeyType,
     ) -> Result<Self, ContainerError<VaultDBError>> {
-        let mut conn = store.get_conn().await?;
+        let conn = store.get_conn().await?;
 
         let query = diesel::update(VaultInner::table())
             .filter(
                 schema::vault::vault_id
-                    .eq(pk.vault_id.as_str())
-                    .and(schema::vault::entity_id.eq(pk.entity_id.as_str())),
+                    .eq(pk.vault_id)
+                    .and(schema::vault::entity_id.eq(pk.entity_id)),
             )
             .set(update);
 
@@ -226,7 +226,7 @@ impl KvUpdatableResource for Vault {
             _,
             _,
             _,
-        >(query.get_result(conn.get_mut()), operation, pool)
+        >(query.get_result_async(conn.get()), operation, pool)
         .await?;
         Ok(output.into())
     }

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -1,5 +1,5 @@
-use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use async_bb8_diesel::AsyncRunQueryDsl;
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 use hyperswitch_masking::PeekInterface;
 
 use crate::{

--- a/src/storage/kv/serializable_query.rs
+++ b/src/storage/kv/serializable_query.rs
@@ -54,7 +54,7 @@ mod pg_type_metadata {
         let pairs: Vec<(u32, u32)> = Vec::deserialize(d)?;
         Ok(pairs
             .into_iter()
-            .map(|(oid, array_oid)| PgTypeMetadata::from_result(Ok((oid, array_oid))))
+            .map(|(oid, array_oid)| PgTypeMetadata::new(oid, array_oid))
             .collect())
     }
 }
@@ -91,7 +91,7 @@ impl diesel::pg::PgMetadataLookup for KvPgMetadataLookup {
         _type_name: &str,
         _schema: Option<&str>,
     ) -> diesel::pg::PgTypeMetadata {
-        diesel::pg::PgTypeMetadata::from_result(Ok((FAKE_OID, FAKE_OID)))
+        diesel::pg::PgTypeMetadata::new(FAKE_OID, FAKE_OID)
     }
 }
 

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "kv"))]
 use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 #[cfg(not(feature = "kv"))]
-use diesel_async::RunQueryDsl;
+use async_bb8_diesel::AsyncRunQueryDsl;
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
 #[cfg(feature = "kv")]
@@ -34,7 +34,7 @@ impl VaultInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             logger::info!("performing insert operation on vault data");
             let query = diesel::insert_into(types::VaultInner::table()).values(new);
 
@@ -46,7 +46,7 @@ impl VaultInterface for Storage {
 
             let output: types::VaultInner =
                 crate::storage::record_db_query::<<types::VaultInner as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -75,13 +75,13 @@ impl VaultInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             logger::info!("performing retrieve operation on vault data");
             // A missing row surfaces (via `?`) as `VaultDBError::NotFoundError`.
             let query = types::VaultInner::table().filter(
                 schema::vault::vault_id
                     .eq(vault_id.expose())
-                    .and(schema::vault::entity_id.eq(entity_id)),
+                    .and(schema::vault::entity_id.eq(entity_id.to_owned())),
             );
 
             let pool = conn.pool();
@@ -92,7 +92,7 @@ impl VaultInterface for Storage {
 
             let output: types::VaultInner =
                 crate::storage::record_db_query::<<types::VaultInner as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -124,14 +124,14 @@ impl VaultInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             logger::info!("performing update operation on vault data");
 
             let query = diesel::update(types::VaultInner::table())
                 .filter(
                     schema::vault::vault_id
                         .eq(vault_id.expose())
-                        .and(schema::vault::entity_id.eq(&entity_id)),
+                        .and(schema::vault::entity_id.eq(entity_id)),
                 )
                 .set(update);
 
@@ -143,7 +143,7 @@ impl VaultInterface for Storage {
 
             let output: types::VaultInner =
                 crate::storage::record_db_query::<<types::VaultInner as HasTable>::Table, _, _, _>(
-                    query.get_result(conn.get_mut()),
+                    query.get_result_async(conn.get()),
                     operation,
                     pool,
                 )
@@ -170,12 +170,12 @@ impl VaultInterface for Storage {
 
         #[cfg(not(feature = "kv"))]
         {
-            let mut conn = self.get_conn().await?;
+            let conn = self.get_conn().await?;
             logger::info!("performing delete operation on vault data");
             let query = diesel::delete(types::VaultInner::table()).filter(
                 schema::vault::vault_id
                     .eq(vault_id.expose())
-                    .and(schema::vault::entity_id.eq(entity_id)),
+                    .and(schema::vault::entity_id.eq(entity_id.to_owned())),
             );
 
             let pool = conn.pool();
@@ -188,7 +188,7 @@ impl VaultInterface for Storage {
                 <types::VaultInner as HasTable>::Table,
                 _,
                 _,
-            >(query.execute(conn.get_mut()), operation, pool)
+            >(query.execute_async(conn.get()), operation, pool)
             .await?;
 
             Ok(output)

--- a/src/storage/storage_v2/db.rs
+++ b/src/storage/storage_v2/db.rs
@@ -1,7 +1,7 @@
 #[cfg(not(feature = "kv"))]
-use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
-#[cfg(not(feature = "kv"))]
 use async_bb8_diesel::AsyncRunQueryDsl;
+#[cfg(not(feature = "kv"))]
+use diesel::{BoolExpressionMethods, ExpressionMethods, QueryDsl, associations::HasTable};
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
 #[cfg(feature = "kv")]

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -39,8 +39,8 @@ impl Merchant {
 
 #[derive(Debug, Insertable)]
 #[diesel(table_name = schema::merchant)]
-pub(crate) struct MerchantNewInner<'a> {
-    pub(super) merchant_id: &'a str,
+pub(crate) struct MerchantNewInner {
+    pub(super) merchant_id: String,
     enc_key: Encrypted,
 }
 
@@ -480,7 +480,7 @@ impl StorageDecryption for MerchantInner {
 }
 
 impl<'a> StorageEncryption for MerchantNew<'a> {
-    type Output = MerchantNewInner<'a>;
+    type Output = MerchantNewInner;
 
     type Algorithm = GcmAes256;
 
@@ -489,7 +489,7 @@ impl<'a> StorageEncryption for MerchantNew<'a> {
         algo: &Self::Algorithm,
     ) -> <Self::Algorithm as Encryption<Vec<u8>, Vec<u8>>>::ReturnType<'_, Self::Output> {
         Ok(Self::Output {
-            merchant_id: self.merchant_id,
+            merchant_id: self.merchant_id.to_string(),
             enc_key: algo.encrypt(self.enc_key.expose())?.into(),
         })
     }


### PR DESCRIPTION
## Summary

- Migrates the DB layer from `diesel_async` + `deadpool` to `diesel` + `async-bb8-diesel`, matching the pattern already used in the main `hyperswitch` repo.
- `async-bb8-diesel` wraps a synchronous `diesel::PgConnection` and dispatches every query onto a blocking thread pool via `bb8`, instead of `diesel_async`'s genuinely async `AsyncPgConnection`. This is a real behavioral/performance trade-off (blocking-thread-pool dispatch vs. true async I/O), not just an API swap — worth a load-test pass before this goes to production traffic.
- `Storage`/`DbConnection` now wrap a `bb8::Pool` + a lifetime-bound pooled connection.
- All query call sites converted to `AsyncRunQueryDsl`'s `_async` methods, which require `'static` queries (since they're moved into `spawn_blocking`) — borrowed filter values (`&str`, `.as_str()`) were changed to owned (`.to_owned()`/`.clone()`) throughout `src/storage/db.rs`, `src/storage/storage_v2/db.rs`, and `src/storage/kv/impls/*.rs`.
- The `/health` DB check (`TestInterface::test()`) is rewritten using `transaction_async`, since `async-bb8-diesel` has no equivalent of `diesel_async`'s `test_transaction` (always-rollback probe). Behaviorally equivalent here since the check inserts then deletes the same row before commit — a real commit and a forced rollback net out to the same DB state.
- `collect_db_pool_state` adapted to `bb8::State` (`connections`, `idle_connections`). Note: bb8 doesn't expose a "waiting for a connection" count the way deadpool's `status()` does, so the `DATABASE_POOL_WAITING` metric is no longer emitted.

## Test cases
### 1. Liveness check

```bash
curl -s -i http://127.0.0.1:3000/health
```
```
HTTP/1.1 200 OK
content-type: application/json

{"message":"Health is good"}
```

### 2. Key custodian — unlock flow

The vault starts locked when `key_custodian` is compiled in. Two key shares (hex, 16 bytes / 32 hex chars each) must be posted before the master key can be decrypted and the tenant's app state (DB pool etc.) is built.

**Before unlock — any DB-backed call is rejected:**
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/add \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"merchant_id":"merchant_1","merchant_customer_id":"cust_1","card":{"card_number":"4242424242424242"},"ttl":null}'
```
```
HTTP/1.1 401 Unauthorized
{"code":"TE_00","message":"Custodian is locked","data":null}
```

**`POST /custodian/key1`**
```bash
curl -s -i -X POST http://127.0.0.1:3000/custodian/key1 \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"key":"ed6c0821308405ef4d5d0cbb2dd2be3d"}'
```
```
HTTP/1.1 200 OK
{"message":"Received Key1"}
```

**`POST /custodian/key2`**
```bash
curl -s -i -X POST http://127.0.0.1:3000/custodian/key2 \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"key":"f02463f2ea9c0d96d7f2487536418217"}'
```
```
HTTP/1.1 200 OK
{"message":"Received Key2"}
```

**`POST /custodian/decrypt`** — derives the AES key from key1+key2, decrypts the master key, and builds the tenant's `TenantAppState` (DB pool included):
```bash
curl -s -i -X POST http://127.0.0.1:3000/custodian/decrypt \
  -H "Content-Type: application/json" -H "x-tenant-id: public"
```
```
HTTP/1.1 200 OK
{"message":"Decryption of Custodian key is successful"}
```

### 3. DB diagnostics (post-unlock)

```bash
curl -s -i http://127.0.0.1:3000/health/diagnostics -H "x-tenant-id: public"
```
```
HTTP/1.1 200 OK
{"key_custodian_locked":false,"database":{"database_connection":"Working","database_read":"Working","database_write":"Working","database_delete":"Working","database_replica":"Disabled"}}
```
Confirms the migrated `async-bb8-diesel` connection/read/write/delete paths all work against real Postgres.

### 4. Entity provisioning

**`POST /entity`** — idempotent; explicitly provisions the key-holder record for a merchant/entity.
```bash
curl -s -i -X POST http://127.0.0.1:3000/entity \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"entity_id":"merchant_1"}'
```
```
HTTP/1.1 200 OK
{"entity_id":"merchant_1","created_at":"2026-08-17T08:51:09.588362000Z"}
```

Calling it again with the same `entity_id` returns the same record unchanged (same `created_at`), confirming idempotency.

### 5. Cards — add / retrieve / delete

**`POST /cards/add`** (structured card data):
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/add \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{
    "merchant_id": "merchant_1",
    "merchant_customer_id": "cust_1",
    "card": {
      "card_number": "4242424242424242",
      "name_on_card": "John Doe",
      "card_exp_month": "12",
      "card_exp_year": "2030",
      "card_brand": "VISA",
      "card_isin": "424242",
      "nick_name": "personal"
    },
    "ttl": null
  }'
```
```
HTTP/1.1 200 OK
{"status":"Ok","payload":{"card_reference":"01a00eea-e2e3-7f11-9da8-aeeb184b34ae","duplication_check":null,"dedup":null}}
```

**Re-adding the identical card data** — dedup detection kicks in:
```
HTTP/1.1 200 OK
{"status":"Ok","payload":{"card_reference":"01a00eea-e2e3-7f11-9da8-aeeb184b34ae","duplication_check":"duplicated","dedup":null}}
```

**`POST /cards/retrieve`**:
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/retrieve \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"merchant_id":"merchant_1","merchant_customer_id":"cust_1","card_reference":"01a00eea-e2e3-7f11-9da8-aeeb184b34ae"}'
```
```
HTTP/1.1 200 OK
{"status":"Ok","payload":{"card":{"card_number":"4242424242424242","name_on_card":"John Doe","card_exp_month":"12","card_exp_year":"2030","card_brand":"VISA","card_isin":"424242","nick_name":"personal"},"enc_card_data":null}}
```
Round-trips correctly decrypted — confirms the KV/encryption read path also works post-migration.

**`POST /cards/delete`**:
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/delete \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"merchant_id":"merchant_1","merchant_customer_id":"cust_1","card_reference":"01a00eea-e2e3-7f11-9da8-aeeb184b34ae"}'
```
```
HTTP/1.1 200 OK
{"status":"Ok"}
```

**Retrieve after delete** — correctly 404s:
```
HTTP/1.1 404 Not Found
{"code":"TE_02","message":"Requested resource not found","data":null}
```

**`POST /cards/add` with pre-encrypted blob** (`enc_card_data` instead of structured `card`, plus a TTL in seconds):
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/add \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"merchant_id":"merchant_1","merchant_customer_id":"cust_2","enc_card_data":"c29tZS1lbmNyeXB0ZWQtYmxvYg==","ttl":300}'
```
```
HTTP/1.1 200 OK
{"status":"Ok","payload":{"card_reference":"01a00eea-e40b-78f3-b63f-a144f2b686f9","duplication_check":null,"dedup":null}}
```

**Validation — invalid card number (fails Luhn/length check):**
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/add \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"merchant_id":"merchant_1","merchant_customer_id":"cust_1","card":{"card_number":"1234"},"ttl":null}'
```
```
HTTP/1.1 400 Bad Request
{"code":"TE_03","message":"Failed while validation: invalid card number length","data":null}
```

### 6. Fingerprint

**`POST /cards/fingerprint`**:
```bash
curl -s -i -X POST http://127.0.0.1:3000/cards/fingerprint \
  -H "Content-Type: application/json" -H "x-tenant-id: public" \
  -d '{"data":"4242424242424242","key":"fingerprinting_key_123"}'
```
```
HTTP/1.1 200 OK
{"fingerprint_id":"EENMbBEMjr2MNGsMIJkX"}
```
Calling again with the same `data`/`key` returns the same `fingerprint_id` (dedup on data+key hash) — same idempotency shape as `create_entity`.