### PR TITLE
feat(runtime-config): per-tenant Postgres source of truth with Redis cache

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,21 @@ All notable changes to hyperswitch-card-vault will be documented here.
 
 - - -
 
+## Unreleased
+
+### Breaking Changes
+
+- **runtime-config:** Replace HTTP polling with per-tenant Postgres + Redis store (no polling). The runtime config source of truth is now the `configs` table in each tenant schema (migration `2026-08-17-120000_create_configs_table`), read-through a per-tenant Redis cache. All TOML `runtime_config.endpoint.*` config keys are replaced by a single `runtime_config.admin_api_key` (env: `LOCKER__RUNTIME_CONFIG__ADMIN_API_KEY`).
+- **runtime-config:** On startup, if `configs` row is missing, seed `{ "use_replica": false, "enable_kv": "disabled" }` and apply the resulting KV / replica transitions. Subsequent changes go through a new authenticated admin endpoint:
+  ```
+  POST /runtime-config
+  Headers: x-tenant-id: <tenant>, x-internal-api-key: <admin_api_key>
+  Body:    {"value": {"use_replica": true, "enable_kv": "enabled"}}
+  ```
+  The endpoint upserts Postgres (the source of truth), invalidates the tenant's Redis cache entry (`DEL` — the TTL bounds staleness on failure), and applies KV / replica state transitions. `GET /health/runtime-config` remains the read-only check.
+
+- - -
+
 ## 0.9.0 (2026-07-31)
 
 ### Features

--- a/config/config.example.toml
+++ b/config/config.example.toml
@@ -153,21 +153,26 @@ background_metrics_collection_interval_secs = 15 # How often to collect metrics 
 # port = 9090                                      # Port the Prometheus HTTP server listens on
 # background_metrics_collection_interval_secs = 15 # How often to collect metrics in the background (in secs)
 
-# Runtime configuration endpoint
+# Runtime configuration stored locally in the per-tenant `configs` Postgres table
+# and read-through a per-tenant Redis cache. No polling.
+#
+# The runtime config source of truth is the per-tenant `configs` table
+# (created by migration 2026-08-17-120000_create_configs_table). The service
+# seeds a safe default (`{"use_replica":false,"enable_kv":"disabled"}`) at
+# startup when the row is absent.
+#
+# The only knob enabled mode adds is the admin API key that guards the
+# `POST /runtime-config` update endpoint:
+#   mode = "enabled"
+#   admin_api_key = "..."   # required when mode is "enabled"
+
 # [runtime_config]
 # mode = "enabled"
-# refresh_interval_seconds = 30
+# admin_api_key = "test_internal_admin_api_key"
 
-# Endpoint needs to be specified if mode is "enabled"
-# [runtime_config.endpoint]
-# base_url = "http://localhost:8090/configs"
-# api_key = "test_admin"
-# path = ""
-#
-# The endpoint at `{base_url}{path}` returns `{"key": "...", "value": "<config json string>"}`,
-# where `value` is a JSON string holding the flat config object, e.g.:
-#   {"key":"locker.configs","value":"{\"enable_kv\":\"enabled\",\"use_replica\":false}"}
-
-# Optional static headers sent on every runtime config pull request (omit entirely to send none)
-# [runtime_config.endpoint.headers]
-# accept = "application/json"
+# Update the runtime config via:
+#   curl -X POST http://<host>:<port>/runtime-config \
+#     -H "x-tenant-id: <tenant>" \
+#     -H "x-internal-api-key: <admin_api_key>" \
+#     -H "Content-Type: application/json" \
+#     -d '{"value":{"use_replica":true,"enable_kv":"enabled"}}'

--- a/migrations/2026-08-17-120000_create_configs_table/down.sql
+++ b/migrations/2026-08-17-120000_create_configs_table/down.sql
@@ -1,0 +1,1 @@
+DROP TABLE IF EXISTS configs;

--- a/migrations/2026-08-17-120000_create_configs_table/up.sql
+++ b/migrations/2026-08-17-120000_create_configs_table/up.sql
@@ -1,0 +1,11 @@
+-- Per-tenant runtime configuration store.
+-- Each tenant schema gets its own `configs` table; the application seeds
+-- a default `locker_runtime_config` row at startup when one is missing.
+-- Both `created_at` and `updated_at` are populated by the application on
+-- insert/update — no database defaults.
+CREATE TABLE IF NOT EXISTS configs (
+    key        VARCHAR(255) PRIMARY KEY,
+    value      JSONB        NOT NULL,
+    created_at TIMESTAMP    NOT NULL,
+    updated_at TIMESTAMP    NOT NULL
+);

--- a/src/app.rs
+++ b/src/app.rs
@@ -55,31 +55,39 @@ impl TenantAppState {
         tenant_config: TenantConfig,
         api_client: ApiClient,
         #[cfg(feature = "redis")] shared_redis: Option<&storage::redis::RedisStore>,
-        runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
-        global_store: Arc<storage::GlobalStore>,
     ) -> error_stack::Result<Self, error::ConfigurationError> {
         #[cfg(feature = "redis")]
         let tenant_redis = shared_redis
             .map(|store| store.clone_with_prefix(tenant_config.redis_key_prefix.trim()));
 
-        #[allow(clippy::map_identity)]
-        let db = storage::Storage::new(
+        let raw_storage = storage::Storage::new(
             &global_config.database,
             global_config.read_replica.as_ref(),
             &tenant_config.tenant_secrets.schema,
-            runtime_config_manager,
-            global_store,
+            #[cfg(feature = "kv")]
+            &global_config.kv,
             #[cfg(feature = "redis")]
             tenant_redis.clone(),
+            #[cfg(feature = "redis")]
+            &global_config.runtime_config,
         )
         .await
-        .map(
-            #[cfg(feature = "caching")]
-            Caching::implement_cache(&global_config.cache),
-            #[cfg(not(feature = "caching"))]
-            std::convert::identity,
-        )
         .change_context(error::ConfigurationError::DatabaseError)?;
+
+        // Seed the configs table with a default row if missing and warm the Redis cache.
+        // A seeding failure is fatal: runtime-config reads would fail closed forever.
+        #[cfg(feature = "redis")]
+        if let Some(manager) = raw_storage.runtime_config_manager() {
+            manager
+                .init(&raw_storage)
+                .await
+                .change_context(error::ConfigurationError::DatabaseError)?;
+        }
+
+        #[cfg(feature = "caching")]
+        let db = Caching::implement_cache(&global_config.cache)(raw_storage);
+        #[cfg(not(feature = "caching"))]
+        let db = raw_storage;
 
         Ok(Self {
             db,
@@ -152,16 +160,6 @@ pub async fn server_builder(
     global_app_state: Arc<GlobalAppState>,
     metrics_handle: observability::MetricsHandle,
 ) -> Result<(), error::ConfigurationError> {
-    // Warm + periodically refresh the runtime-config cache. No-op when disabled.
-    let runtime_config_manager = global_app_state.runtime_config_manager.clone();
-    let state_for_prefetch = global_app_state.clone();
-    let _prefetch_handle = runtime_config_manager.spawn_prefetch_task(move || {
-        let state_for_prefetch = state_for_prefetch.clone();
-        async move {
-            state_for_prefetch.apply_runtime_config_updates().await;
-        }
-    });
-
     let socket_addr = std::net::SocketAddr::new(
         global_app_state.global_config.server.host.parse()?,
         global_app_state.global_config.server.port,
@@ -213,6 +211,16 @@ pub async fn server_builder(
             global_app_state.clone(),
             custom_middleware::middleware,
         ));
+    }
+
+    // Everything below is added *after* the JWE middleware layer, so these routes are
+    // plain JSON: internal admin APIs and health checks are never JWE-encrypted.
+    #[cfg(feature = "redis")]
+    {
+        router = router.route(
+            "/runtime-config",
+            post(routes::runtime_config::update_runtime_config),
+        );
     }
 
     #[cfg(feature = "external_key_manager")]

--- a/src/config.rs
+++ b/src/config.rs
@@ -5,7 +5,9 @@ use std::{
 };
 
 use error_stack::ResultExt;
-use hyperswitch_masking::{ExposeInterface, PeekInterface, Secret};
+#[cfg(feature = "redis")]
+use hyperswitch_masking::PeekInterface;
+use hyperswitch_masking::{ExposeInterface, Secret};
 #[cfg(feature = "redis")]
 use hyperswitch_redis_interface::RedisSettings;
 
@@ -42,6 +44,7 @@ pub struct GlobalConfig {
     pub external_key_manager: ExternalKeyManagerConfig,
     #[cfg(feature = "redis")]
     pub redis: Option<RedisSettings>,
+    #[cfg(feature = "redis")]
     #[serde(default)]
     pub runtime_config: RuntimeConfig,
     #[cfg(feature = "kv")]
@@ -321,15 +324,16 @@ impl GlobalConfig {
                 ))?;
         }
 
+        #[cfg(feature = "redis")]
         if let RuntimeConfig::Enabled {
-            ref mut endpoint, ..
+            ref mut admin_api_key,
         } = self.runtime_config
         {
-            endpoint.api_key = secret_management_client
-                .get_secret(endpoint.api_key.clone())
+            *admin_api_key = secret_management_client
+                .get_secret(admin_api_key.clone())
                 .await
                 .change_context(error::ConfigurationError::KmsDecryptError(
-                    "runtime_config api_key",
+                    "runtime_config admin_api_key",
                 ))?;
         }
 
@@ -370,7 +374,11 @@ impl GlobalConfig {
 
     pub fn validate(&self) -> error_stack::Result<(), error::ConfigurationError> {
         self.secrets_management.validate()?;
-        self.runtime_config.validate()?;
+        #[cfg(feature = "redis")]
+        {
+            self.runtime_config.validate()?;
+            self.validate_runtime_config_redis()?;
+        }
         #[cfg(feature = "kv")]
         {
             self.kv.validate()?;
@@ -384,6 +392,18 @@ impl GlobalConfig {
         }
         self.metrics.validate()?;
 
+        Ok(())
+    }
+
+    /// Runtime config is read-through a per-tenant Redis cache — it cannot operate
+    /// without Redis configured.
+    #[cfg(feature = "redis")]
+    fn validate_runtime_config_redis(&self) -> Result<(), error::ConfigurationError> {
+        if self.runtime_config.is_enabled() && self.redis.is_none() {
+            return Err(error::ConfigurationError::InvalidConfigurationValueError(
+                "runtime_config is enabled but `[redis]` is not configured".into(),
+            ));
+        }
         Ok(())
     }
 
@@ -509,57 +529,39 @@ impl std::fmt::Display for Env {
     }
 }
 
-#[derive(Debug, Clone, serde::Deserialize)]
-pub struct RuntimeConfigEndpoint {
-    pub base_url: String,
-    pub api_key: hyperswitch_masking::Secret<String>,
-    #[serde(default)]
-    pub headers: std::collections::HashMap<String, hyperswitch_masking::Secret<String>>,
-    #[serde(default)]
-    pub path: String,
-}
-
 /// Runtime configuration source.
+///
+/// When enabled, the runtime config (`use_replica`, `enable_kv`) is stored in the
+/// per-tenant `configs` Postgres table and read-through a per-tenant Redis cache.
+/// The `admin_api_key` guards the `POST /runtime-config` update endpoint.
+/// Only available with the `redis` feature — runtime config never operates without
+/// its Redis read-through cache.
+#[cfg(feature = "redis")]
 #[derive(Debug, Clone, Default, serde::Deserialize)]
 #[serde(tag = "mode", rename_all = "snake_case")]
 pub enum RuntimeConfig {
     #[default]
     Disabled,
     Enabled {
-        endpoint: RuntimeConfigEndpoint,
-        #[serde(default = "default_runtime_config_refresh_interval_seconds")]
-        refresh_interval_seconds: u64,
+        admin_api_key: hyperswitch_masking::Secret<String>,
     },
 }
 
-fn default_runtime_config_refresh_interval_seconds() -> u64 {
-    30
-}
-
+#[cfg(feature = "redis")]
 impl RuntimeConfig {
     pub fn is_enabled(&self) -> bool {
         matches!(self, Self::Enabled { .. })
     }
 
     pub fn validate(&self) -> Result<(), crate::error::ConfigurationError> {
-        if let Self::Enabled { endpoint, .. } = self {
-            if endpoint.base_url.trim().is_empty() {
-                return Err(
-                    crate::error::ConfigurationError::InvalidConfigurationValueError(
-                        r#"runtime_config.endpoint.base_url is required when mode is "enabled""#
-                            .into(),
-                    ),
-                );
-            }
-
-            if endpoint.api_key.peek().trim().is_empty() {
-                return Err(
-                    crate::error::ConfigurationError::InvalidConfigurationValueError(
-                        r#"runtime_config.endpoint.api_key is required when mode is "enabled""#
-                            .into(),
-                    ),
-                );
-            }
+        if let Self::Enabled { admin_api_key } = self
+            && admin_api_key.peek().trim().is_empty()
+        {
+            return Err(
+                crate::error::ConfigurationError::InvalidConfigurationValueError(
+                    r#"runtime_config.admin_api_key is required when mode is "enabled""#.into(),
+                ),
+            );
         }
 
         Ok(())

--- a/src/error.rs
+++ b/src/error.rs
@@ -70,6 +70,35 @@ pub enum StorageError {
     UpdateError,
     #[error("Read replica pool is not configured")]
     ReplicaPoolNotConfigured,
+    #[error("Storage initialization failed: {0}")]
+    InitializationError(&'static str),
+}
+
+/// Errors from the runtime-config manager (`configs` table + Redis cache).
+#[cfg(feature = "redis")]
+#[derive(Debug, thiserror::Error)]
+pub enum RuntimeConfigError {
+    /// The runtime-config payload could not be (de)serialized.
+    #[error("Invalid runtime config value: {0}")]
+    InvalidValue(String),
+    /// Illegal `enable_kv` state transition for the currently persisted state.
+    #[error("Invalid KV state transition: {0}")]
+    InvalidStateTransition(String),
+    /// `use_replica: true` was requested but no read replica pool is configured.
+    #[error("Cannot enable use_replica: no read replica is configured")]
+    NoReplicaConfigured,
+    /// `use_replica: true` was requested but the read replica is unreachable.
+    #[error("Cannot enable use_replica: read replica is unreachable")]
+    ReplicaUnreachable,
+    /// The backing store (Postgres/Redis) errored — see attached report.
+    #[error("Runtime config storage operation failed")]
+    StorageError,
+    /// The requested config row was not found in the `configs` table.
+    #[error("Runtime config not found")]
+    NotFound,
+    /// A config row with the same key already exists in the `configs` table.
+    #[error("Runtime config already exists")]
+    Duplicate,
 }
 
 #[derive(Debug, Copy, Clone, thiserror::Error)]
@@ -130,6 +159,12 @@ pub enum ApiError {
 
     #[error("Key manager error: {0}")]
     KeyManagerError(&'static str),
+
+    #[error("Unauthorized")]
+    Unauthorized,
+
+    #[error("Bad request: {0}")]
+    BadRequest(&'static str),
 }
 
 /// Errors that could occur during KMS operations.
@@ -408,6 +443,24 @@ impl axum::response::IntoResponse for ApiError {
                 hyper::StatusCode::INTERNAL_SERVER_ERROR,
                 axum::Json(ApiErrorResponse::new(
                     error_codes::TE_02,
+                    format!("{}", data),
+                    None,
+                )),
+            )
+                .into_response(),
+            data @ Self::Unauthorized => (
+                hyper::StatusCode::UNAUTHORIZED,
+                axum::Json(ApiErrorResponse::new(
+                    error_codes::TE_00,
+                    format!("{}", data),
+                    None,
+                )),
+            )
+                .into_response(),
+            data @ Self::BadRequest(_) => (
+                hyper::StatusCode::BAD_REQUEST,
+                axum::Json(ApiErrorResponse::new(
+                    error_codes::TE_03,
                     format!("{}", data),
                     None,
                 )),

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -1,3 +1,4 @@
+#[cfg(feature = "redis")]
 use super::RuntimeConfigError;
 
 #[derive(Debug, thiserror::Error)]

--- a/src/error/custom_error.rs
+++ b/src/error/custom_error.rs
@@ -1,3 +1,5 @@
+use super::RuntimeConfigError;
+
 #[derive(Debug, thiserror::Error)]
 pub enum MerchantDBError {
     #[error("Error while encrypting DEK before adding to DB")]
@@ -231,4 +233,11 @@ impl_storage_error!(
     duplicate = Duplicate,
     not_found = NotFoundError,
     other = DBError
+);
+#[cfg(feature = "redis")]
+impl_storage_error!(
+    RuntimeConfigError,
+    duplicate = Duplicate,
+    not_found = NotFound,
+    other = StorageError
 );

--- a/src/error/transforms.rs
+++ b/src/error/transforms.rs
@@ -34,7 +34,8 @@ impl<'a> From<&'a super::StorageError> for super::MerchantDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::DecryptionError
             | super::StorageError::EncryptionError
@@ -53,7 +54,8 @@ impl<'a> From<&'a super::StorageError> for super::VaultDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::DecryptionError | super::StorageError::EncryptionError => {
                 Self::UnknownError
@@ -73,7 +75,8 @@ impl<'a> From<&'a super::StorageError> for super::HashDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::DecryptionError
             | super::StorageError::EncryptionError
@@ -102,6 +105,7 @@ impl<'a> From<&'a super::StorageError> for super::TestDBError {
             | super::StorageError::EncryptionError
             | super::StorageError::NotFoundError => Self::UnknownError,
             super::StorageError::ReplicaPoolNotConfigured => Self::DBReplicaNotConfigured,
+            super::StorageError::InitializationError(_) => Self::UnknownError,
         }
     }
 }
@@ -112,7 +116,8 @@ impl<'a> From<&'a super::StorageError> for super::FingerprintDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError | super::StorageError::NotFoundError => {
                 Self::DBFilterError
             }
@@ -258,7 +263,8 @@ impl<'a> From<&'a super::StorageError> for super::EntityDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::NotFoundError => Self::NotFoundError,
             super::StorageError::DecryptionError
@@ -306,7 +312,8 @@ impl<'a> From<&'a super::StorageError> for super::ReverseLookupDBError {
         match value {
             super::StorageError::DBPoolError
             | super::StorageError::PoolClientFailure
-            | super::StorageError::ReplicaPoolNotConfigured => Self::DBError,
+            | super::StorageError::ReplicaPoolNotConfigured
+            | super::StorageError::InitializationError(_) => Self::DBError,
             super::StorageError::FindError => Self::DBFilterError,
             super::StorageError::NotFoundError => Self::NotFoundError,
             super::StorageError::DecryptionError
@@ -333,6 +340,29 @@ impl<'a> From<&'a super::ReverseLookupDBError> for super::ApiError {
             super::ReverseLookupDBError::Duplicate => Self::DatabaseInsertFailed("reverse lookup"),
             super::ReverseLookupDBError::NotFoundError => Self::NotFoundError,
             super::ReverseLookupDBError::UnknownError => Self::UnknownError,
+        }
+    }
+}
+
+#[cfg(feature = "redis")]
+error_transform!(super::RuntimeConfigError => super::ApiError);
+#[cfg(feature = "redis")]
+impl<'a> From<&'a super::RuntimeConfigError> for super::ApiError {
+    fn from(value: &'a super::RuntimeConfigError) -> Self {
+        match value {
+            super::RuntimeConfigError::InvalidValue(_) => {
+                Self::BadRequest("Invalid runtime config value")
+            }
+            super::RuntimeConfigError::InvalidStateTransition(_) => {
+                Self::BadRequest("Invalid KV state transition")
+            }
+            super::RuntimeConfigError::NoReplicaConfigured
+            | super::RuntimeConfigError::ReplicaUnreachable => {
+                Self::BadRequest("Cannot enable use_replica")
+            }
+            super::RuntimeConfigError::StorageError
+            | super::RuntimeConfigError::NotFound
+            | super::RuntimeConfigError::Duplicate => Self::DatabaseError,
         }
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,7 @@ pub mod logger;
 pub mod middleware;
 pub mod observability;
 pub mod routes;
+#[cfg(feature = "redis")]
 pub mod runtime_config;
 pub mod storage;
 pub mod tenant;

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -6,6 +6,8 @@ pub mod key_custodian;
 #[cfg(feature = "external_key_manager")]
 pub mod key_migration;
 pub mod routes_v2;
+#[cfg(feature = "redis")]
+pub mod runtime_config;
 
 fn record_expired_data_encountered(resource: crate::observability::metrics::Resource) {
     crate::observability::metrics::TTL_EXPIRED_DATA_ENCOUNTERED_COUNT

--- a/src/routes/health.rs
+++ b/src/routes/health.rs
@@ -28,10 +28,14 @@ where
 /// Function for registering routes that is specifically handling the health apis
 ///
 pub fn serve() -> axum::Router<Arc<GlobalAppState>> {
-    axum::Router::new()
+    let router = axum::Router::new()
         .route("/", get(health))
-        .route("/diagnostics", get(diagnostics))
-        .route("/runtime-config", get(runtime_config_status))
+        .route("/diagnostics", get(diagnostics));
+
+    #[cfg(feature = "redis")]
+    let router = router.route("/runtime-config", get(runtime_config_status));
+
+    router
 }
 
 #[derive(serde::Serialize, Debug)]
@@ -49,6 +53,7 @@ pub async fn health() -> Json<HealthRespPayload> {
 }
 
 /// '/health/runtime-config` API handler`
+#[cfg(feature = "redis")]
 #[tracing::instrument(skip_all)]
 pub async fn runtime_config_status(
     TenantStateResolver(state): TenantStateResolver,

--- a/src/routes/key_custodian.rs
+++ b/src/routes/key_custodian.rs
@@ -124,8 +124,6 @@ pub async fn decrypt(
                 global_app_state.api_client.clone(),
                 #[cfg(feature = "redis")]
                 global_app_state.redis_store.as_ref(),
-                global_app_state.runtime_config_manager.clone(),
-                global_app_state.storage_global_store.clone(),
             )
             .await
             .change_context(error::ApiError::TenantError(

--- a/src/routes/runtime_config.rs
+++ b/src/routes/runtime_config.rs
@@ -54,7 +54,7 @@ pub async fn update_runtime_config(
             ))?;
 
     if !manager.verify_admin_api_key(api_key_header) {
-        return Err(error::ApiError::Unauthorized)?;
+        Err(error::ApiError::Unauthorized)?;
     }
 
     manager

--- a/src/routes/runtime_config.rs
+++ b/src/routes/runtime_config.rs
@@ -1,0 +1,68 @@
+//! Admin endpoint for runtime config updates.
+//!
+//! `POST /runtime-config` validates state transitions, writes the config body into the
+//! per-tenant `configs` Postgres table, and invalidates the tenant's Redis cache entry.
+//! No in-process state is applied — every consumer (KV routing, replica routing) reads
+//! the config per-operation from Postgres via the tenant's Redis cache.
+
+use std::sync::Arc;
+
+use axum::{Json, extract::State, http::HeaderMap};
+
+use crate::{
+    custom_extractors::TenantStateResolver,
+    error::{self, ContainerError},
+    tenant::GlobalAppState,
+};
+
+#[derive(serde::Deserialize)]
+pub struct UpdateRuntimeConfigRequest {
+    /// Raw config body, e.g. `{"use_replica":true,"enable_kv":"enabled"}`.
+    /// Unknown fields are rejected by `RuntimeConfigValues::deserialize`.
+    pub value: serde_json::Value,
+}
+
+#[derive(serde::Serialize)]
+pub struct UpdateRuntimeConfigResponse {
+    /// The applied config value (echo back).
+    pub value: serde_json::Value,
+}
+
+/// `POST /runtime-config`
+///
+/// Auth:
+///   - `x-tenant-id`        → tenant whose config table is updated
+///   - `x-internal-api-key` → shared secret — must match `runtime_config.admin_api_key`
+#[tracing::instrument(skip_all)]
+pub async fn update_runtime_config(
+    State(_global_app_state): State<Arc<GlobalAppState>>,
+    headers: HeaderMap,
+    TenantStateResolver(tenant_app_state): TenantStateResolver,
+    Json(payload): Json<UpdateRuntimeConfigRequest>,
+) -> Result<Json<UpdateRuntimeConfigResponse>, ContainerError<error::ApiError>> {
+    let api_key_header = headers
+        .get("x-internal-api-key")
+        .and_then(|v| v.to_str().ok())
+        .ok_or(error::ApiError::Unauthorized)?;
+
+    let manager =
+        tenant_app_state
+            .db
+            .runtime_config_manager()
+            .ok_or(error::ApiError::BadRequest(
+                "Runtime config is not enabled for this tenant",
+            ))?;
+
+    if !manager.verify_admin_api_key(api_key_header) {
+        return Err(error::ApiError::Unauthorized)?;
+    }
+
+    manager
+        .update(&tenant_app_state.db, payload.value.clone())
+        .await
+        .map_err(ContainerError::<error::ApiError>::from)?;
+
+    Ok(Json(UpdateRuntimeConfigResponse {
+        value: payload.value,
+    }))
+}

--- a/src/runtime_config.rs
+++ b/src/runtime_config.rs
@@ -1,33 +1,15 @@
-use std::{collections::HashMap, future::Future, sync::Arc, time::Duration};
+use std::time::Instant;
 
-use error_stack::ResultExt;
-use hyperswitch_masking::{PeekInterface, Secret};
-use tokio::sync::RwLock;
-use tracing::Instrument;
+use hyperswitch_masking::PeekInterface;
 
-use crate::{config::RuntimeConfig, error};
+use crate::{
+    config::RuntimeConfig,
+    error::{self, ContainerError},
+    storage::{self, ConfigInterface, consts},
+};
 
-const API_KEY_HEADER_NAME: &str = "X-Internal-Api-Key";
-
-/// Endpoint envelope: `{"key": "...", "value": "<config json string>"}`. Only `value` is used —
-/// it's a JSON string holding the flat config object (`{"enable_kv": "...", ...}`).
-#[derive(serde::Deserialize)]
-struct RuntimeConfigResponse {
-    value: String,
-}
-
-enum RuntimeConfigState {
-    Disabled,
-    Enabled {
-        endpoint_url: String,
-        endpoint_path: String,
-        api_key: Secret<String>,
-        client: reqwest::Client,
-        refresh_interval: Duration,
-        /// Last-known-good config body; `None` until the first successful fetch.
-        cache: RwLock<Option<String>>,
-    },
-}
+/// The key identifying the runtime config in both Postgres and Redis.
+const CONFIG_KEY: &str = consts::RUNTIME_CONFIG_KEY;
 
 #[derive(Debug, serde::Serialize)]
 pub struct RuntimeConfigStatus {
@@ -40,92 +22,81 @@ pub struct RuntimeConfigStatus {
 #[serde(rename_all = "snake_case")]
 pub enum RuntimeConfigStatusKind {
     Disabled,
-    NotFetched,
+    NotConfigured,
     Available,
     Invalid,
 }
 
-/// Fetches the runtime-config endpoint on a schedule and serves the last-known-good body.
+/// Manages runtime configuration (`use_replica`, `enable_kv`) backed by the per-tenant
+/// `configs` Postgres table with a read-through per-tenant Redis cache.
+///
+/// No polling: every `get()` fetches the latest value from Redis (or Postgres on a cache
+/// miss). `update()` upserts to Postgres and invalidates the Redis cache entry.
 pub struct RuntimeConfigManager {
-    state: RuntimeConfigState,
+    admin_api_key: hyperswitch_masking::Secret<String>,
 }
 
 impl RuntimeConfigManager {
-    fn build_header_map(
-        headers: &HashMap<String, Secret<String>>,
-    ) -> error_stack::Result<reqwest::header::HeaderMap, error::ConfigurationError> {
-        headers
-            .iter()
-            .map(|(name, value)| {
-                let header_name = reqwest::header::HeaderName::from_bytes(name.as_bytes())
-                    .change_context(error::ConfigurationError::InvalidConfigurationValueError(
-                        format!("invalid runtime_config header name `{name}`"),
-                    ))?;
-                let mut header_value = reqwest::header::HeaderValue::from_str(value.peek())
-                    .change_context(error::ConfigurationError::InvalidConfigurationValueError(
-                        format!("invalid runtime_config header value for `{name}`"),
-                    ))?;
-                header_value.set_sensitive(true);
-                Ok((header_name, header_value))
-            })
-            .collect()
+    /// Construct a runtime config manager from the global `RuntimeConfig` settings.
+    /// Returns `None` when runtime config is disabled — a manager only exists when the
+    /// feature is enabled, so its `admin_api_key` is always present. The owning tenant's
+    /// `Storage` is passed to each method — the manager holds no storage handle of its own.
+    pub fn new(config: &RuntimeConfig) -> Option<Self> {
+        match config {
+            RuntimeConfig::Enabled { admin_api_key } => Some(Self {
+                admin_api_key: admin_api_key.clone(),
+            }),
+            RuntimeConfig::Disabled => None,
+        }
     }
 
-    /// Construct a new runtime config manager.
-    pub fn new(
-        config: &RuntimeConfig,
-        client_idle_timeout: u64,
-        pool_max_idle_per_host: usize,
-    ) -> error_stack::Result<Self, error::ConfigurationError> {
-        Ok(match config {
-            RuntimeConfig::Disabled => Self {
-                state: RuntimeConfigState::Disabled,
-            },
-            RuntimeConfig::Enabled {
-                endpoint,
-                refresh_interval_seconds,
-            } => {
-                let client = reqwest::Client::builder()
-                    .redirect(reqwest::redirect::Policy::none())
-                    .pool_idle_timeout(Duration::from_secs(client_idle_timeout))
-                    .pool_max_idle_per_host(pool_max_idle_per_host)
-                    .default_headers(Self::build_header_map(&endpoint.headers)?)
-                    .build()
-                    .change_context(error::ConfigurationError::InvalidConfigurationValueError(
-                        "Failed to build HTTP client for runtime config endpoint".into(),
-                    ))?;
-
-                Self {
-                    state: RuntimeConfigState::Enabled {
-                        endpoint_url: endpoint.base_url.clone(),
-                        endpoint_path: endpoint.path.clone(),
-                        api_key: endpoint.api_key.clone(),
-                        client,
-                        refresh_interval: Duration::from_secs(*refresh_interval_seconds),
-                        cache: RwLock::new(None),
-                    },
-                }
-            }
-        })
-    }
-
-    /// Deserialize the last-known-good config body into `T`.
+    /// Bootstrap: ensure a `configs` row exists (seed the safe default if missing) and
+    /// warm the Redis cache.
     ///
-    /// Returns `None` when the manager is disabled, no config has been fetched yet, or the
-    /// cached payload cannot be deserialized into `T`.
-    pub async fn get<T: serde::de::DeserializeOwned>(&self) -> Option<T> {
-        let RuntimeConfigState::Enabled { cache, .. } = &self.state else {
-            crate::logger::debug!("Runtime config disabled");
-            return None;
-        };
+    /// Fails when the seed read or upsert errors — the tenant must not start serving
+    /// with no runtime-config row. The Redis warm is best-effort only: a failed warm
+    /// self-heals on the next read (read-through populate, TTL-bounded).
+    pub async fn init(
+        &self,
+        store: &storage::Storage,
+    ) -> Result<(), ContainerError<error::RuntimeConfigError>> {
+        let existing = store.find_config(CONFIG_KEY).await.inspect_err(|err| {
+            crate::logger::error!(
+                ?err,
+                "Failed to read runtime config from Postgres during init"
+            );
+        })?;
 
-        let guard = cache.read().await;
-        let Some(raw) = guard.as_deref() else {
-            crate::logger::debug!("Runtime config not fetched yet");
-            return None;
-        };
+        match existing {
+            Some(_) => {
+                crate::logger::debug!("Runtime config already present in Postgres");
+            }
+            None => {
+                let default = storage::RuntimeConfigValues::default();
+                let value = serde_json::to_value(&default).map_err(|err| {
+                    ContainerError::from(error::RuntimeConfigError::InvalidValue(err.to_string()))
+                })?;
+                store.upsert_config(CONFIG_KEY, value).await.inspect(|_| {
+                    crate::logger::info!("Seeded default runtime config into Postgres");
+                })?;
+            }
+        }
 
-        match serde_json::from_str::<T>(raw) {
+        // Warm the Redis cache (read-through populates Redis on a miss).
+        let _ = self.get::<serde_json::Value>(store).await;
+        Ok(())
+    }
+
+    /// Deserialize the latest runtime config into `T`.
+    ///
+    /// Read-through: Redis GET → on hit, return immediately; on miss/error, fall back to
+    /// Postgres SELECT and best-effort populate Redis. Returns `None` when no config row
+    /// exists or both stores are unavailable (fail-closed: callers treat `None` as
+    /// KV-disabled / replica-off).
+    pub async fn get<T: serde::de::DeserializeOwned>(&self, store: &storage::Storage) -> Option<T> {
+        let raw = self.get_raw(store).await?;
+
+        match serde_json::from_str::<T>(&raw) {
             Ok(val) => Some(val),
             Err(error) => {
                 crate::logger::error!(?error, raw, "Failed to deserialize runtime config");
@@ -134,187 +105,203 @@ impl RuntimeConfigManager {
         }
     }
 
-    /// Returns the current cached runtime-config status without fetching from the endpoint.
-    pub async fn status(&self) -> RuntimeConfigStatus {
-        let RuntimeConfigState::Enabled { cache, .. } = &self.state else {
-            return RuntimeConfigStatus {
-                status: RuntimeConfigStatusKind::Disabled,
-                config: None,
-            };
+    /// Fetch the raw JSON string, going through the read-through Redis cache.
+    async fn get_raw(&self, store: &storage::Storage) -> Option<String> {
+        let start = Instant::now();
+        let fetch_from_pg = || async {
+            store
+                .find_config(CONFIG_KEY)
+                .await
+                .inspect_err(|err| {
+                    crate::logger::error!(?err, "Failed to read runtime config from Postgres");
+                })
+                .ok()
+                .flatten()
+                .map(|value| value.to_string())
         };
 
-        let guard = cache.read().await;
-        let Some(raw) = guard.as_deref() else {
-            return RuntimeConfigStatus {
-                status: RuntimeConfigStatusKind::NotFetched,
-                config: None,
-            };
-        };
-
-        match serde_json::from_str(raw) {
-            Ok(config) => RuntimeConfigStatus {
-                status: RuntimeConfigStatusKind::Available,
-                config: Some(config),
-            },
-            Err(error) => {
-                crate::logger::error!(?error, raw, "Cached runtime config is invalid");
-                RuntimeConfigStatus {
-                    status: RuntimeConfigStatusKind::Invalid,
-                    config: None,
-                }
+        #[cfg(feature = "redis")]
+        let (source, result) = match store.get_redis_store() {
+            Some(redis) => {
+                let result = redis
+                    .get_or_populate(
+                        CONFIG_KEY,
+                        consts::RUNTIME_CONFIG_REDIS_TTL_SECS,
+                        fetch_from_pg,
+                    )
+                    .await;
+                ("redis", result)
             }
-        }
-    }
-
-    /// Spawn a background task that refreshes the config on an interval. Returns `None` when disabled.
-    pub fn spawn_prefetch_task<F, Fut>(
-        self: &Arc<Self>,
-        on_successful_fetch: F,
-    ) -> Option<tokio::task::JoinHandle<()>>
-    where
-        F: Fn() -> Fut + Send + Sync + 'static,
-        Fut: Future<Output = ()> + Send + 'static,
-    {
-        let refresh_interval = match &self.state {
-            RuntimeConfigState::Disabled => return None,
-            RuntimeConfigState::Enabled {
-                refresh_interval, ..
-            } => *refresh_interval,
+            None => {
+                crate::logger::debug!("Redis not configured, reading runtime config from Postgres");
+                ("postgres", fetch_from_pg().await)
+            }
         };
 
-        let manager = Arc::clone(self);
-        crate::logger::info!(
-            refresh_interval_secs = refresh_interval.as_secs(),
-            "Spawning runtime config prefetch task"
+        #[cfg(not(feature = "redis"))]
+        let (source, result) = ("postgres", fetch_from_pg().await);
+
+        crate::observability::metrics::RUNTIME_CONFIG_FETCH_DURATION.record(
+            start.elapsed().as_secs_f64(),
+            metrics_utils::metric_attributes!(
+                ("source", source),
+                (
+                    "outcome",
+                    if result.is_some() { "success" } else { "error" }
+                )
+            ),
         );
 
-        Some(tokio::spawn(
-            async move {
-                if manager.prefetch().await {
-                    on_successful_fetch().await;
-                }
+        result
+    }
 
-                let mut ticker = tokio::time::interval(refresh_interval);
-                ticker.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
+    /// Update the runtime config: validate → check transition → PG upsert → Redis invalidate.
+    ///
+    /// The requested KV state transition is validated against the currently persisted
+    /// state (Postgres/Redis cache) — there is no in-process KV state to consult.
+    /// The Redis `DEL` failure is logged as a warning (not propagated) because the
+    /// Redis TTL bounds staleness — the next read will eventually repopulate from PG.
+    pub async fn update(
+        &self,
+        store: &storage::Storage,
+        value: serde_json::Value,
+    ) -> Result<(), ContainerError<error::RuntimeConfigError>> {
+        // Validate by parsing into RuntimeConfigValues (fails closed on unknown fields).
+        let requested = serde_json::from_value::<storage::RuntimeConfigValues>(value.clone())
+            .map_err(|err| {
+                ContainerError::from(error::RuntimeConfigError::InvalidValue(err.to_string()))
+            })?;
 
-                loop {
-                    ticker.tick().await;
-                    if manager.prefetch().await {
-                        on_successful_fetch().await;
-                    }
-                }
-            }
-            .in_current_span(),
+        #[cfg(feature = "kv")]
+        self.validate_kv_transition(store, requested.enable_kv)
+            .await?;
+
+        self.validate_replica_enablement(store, requested.use_replica)
+            .await?;
+
+        store.upsert_config(CONFIG_KEY, value).await?;
+
+        #[cfg(feature = "redis")]
+        if let Some(redis) = store.get_redis_store() {
+            redis.invalidate(CONFIG_KEY).await;
+        }
+
+        Ok(())
+    }
+
+    /// Reject illegal KV state transitions against the currently persisted state.
+    ///
+    /// `Disabled → Enabled` additionally requires a reachable Redis backend, since KV
+    /// writes go through Redis.
+    #[cfg(feature = "kv")]
+    async fn validate_kv_transition(
+        &self,
+        store: &storage::Storage,
+        requested: storage::kv::KvState,
+    ) -> Result<(), ContainerError<error::RuntimeConfigError>> {
+        use storage::kv::KvState;
+
+        let current = self
+            .get::<storage::RuntimeConfigValues>(store)
+            .await
+            .map(|values| values.enable_kv)
+            .unwrap_or(KvState::Disabled);
+
+        let can_enable_kv = match store.get_redis_store() {
+            Some(redis) => redis
+                .test()
+                .await
+                .inspect_err(|err| {
+                    crate::logger::error!(
+                        ?err,
+                        "Redis health check failed while validating KV enablement"
+                    );
+                })
+                .is_ok(),
+            None => false,
+        };
+
+        if current.is_valid_transition(requested, can_enable_kv) {
+            return Ok(());
+        }
+
+        crate::logger::warn!(
+            current = %current,
+            requested = %requested,
+            "KV state transition rejected"
+        );
+        Err(ContainerError::from(
+            error::RuntimeConfigError::InvalidStateTransition(format!("{current} -> {requested}")),
         ))
     }
 
-    async fn prefetch(&self) -> bool {
-        let RuntimeConfigState::Enabled {
-            endpoint_url,
-            endpoint_path,
-            api_key,
-            client,
-            cache,
-            ..
-        } = &self.state
-        else {
-            return false;
-        };
-
-        match Self::fetch_config(endpoint_url, endpoint_path, api_key, client).await {
-            Ok(body) => {
-                crate::logger::info!(config = %body, "Runtime config fetched");
-                *cache.write().await = Some(body);
-                true
-            }
-            Err(e) => {
-                crate::logger::warn!(
-                    error = ?e,
-                    "Failed to prefetch runtime config, keeping last-known-good"
-                );
-                false
-            }
+    /// Reject enabling replica reads when no replica pool is configured or the replica
+    /// is unreachable. Mirrors the previous global-state refresh behaviour, enforced at
+    /// the only write path now (no in-process state to consult).
+    async fn validate_replica_enablement(
+        &self,
+        store: &storage::Storage,
+        requested_use_replica: bool,
+    ) -> Result<(), ContainerError<error::RuntimeConfigError>> {
+        if !requested_use_replica {
+            return Ok(());
         }
-    }
 
-    /// Fetch the config endpoint and return the inner config JSON string (the envelope's `value`).
-    /// Validated as JSON so a malformed 2xx response can't overwrite the last-known-good entry.
-    async fn fetch_config(
-        endpoint_url: &str,
-        endpoint_path: &str,
-        api_key: &Secret<String>,
-        client: &reqwest::Client,
-    ) -> error_stack::Result<String, error::ConfigurationError> {
-        let url = format!(
-            "{}/{}",
-            endpoint_url.trim_end_matches('/'),
-            endpoint_path.trim_start_matches('/')
-        );
-
-        crate::logger::debug!(url = %url, "Fetching runtime config");
-
-        let request = client.get(&url).header(API_KEY_HEADER_NAME, api_key.peek());
-        let response = record_runtime_config_fetch_duration(request)
-            .await
-            .change_context(error::ConfigurationError::InvalidConfigurationValueError(
-                "Failed to send runtime config request".into(),
-            ))?;
-
-        if !response.status().is_success() {
-            return Err(error_stack::report!(
-                error::ConfigurationError::InvalidConfigurationValueError(format!(
-                    "Runtime config request returned non-success status ({})",
-                    response.status()
-                ))
+        if !store.has_replica() {
+            return Err(ContainerError::from(
+                error::RuntimeConfigError::NoReplicaConfigured,
             ));
         }
 
-        let RuntimeConfigResponse { value } = response.json().await.change_context(
-            error::ConfigurationError::InvalidConfigurationValueError(
-                "Failed to parse runtime config response envelope".into(),
-            ),
-        )?;
+        store.get_replica_conn().await.map(|_| ()).map_err(|err| {
+            crate::logger::error!(
+                ?err,
+                "Replica health check failed while validating use_replica"
+            );
+            ContainerError::from(error::RuntimeConfigError::ReplicaUnreachable)
+        })
+    }
 
-        serde_json::from_str::<serde_json::Value>(&value).change_context(
-            error::ConfigurationError::InvalidConfigurationValueError(
-                "Runtime config value is not valid JSON".into(),
-            ),
-        )?;
+    /// Returns the current runtime-config status without side effects.
+    pub async fn status(&self, store: &storage::Storage) -> RuntimeConfigStatus {
+        let raw = self.get_raw(store).await;
 
-        Ok(value)
+        match raw {
+            None => RuntimeConfigStatus {
+                status: RuntimeConfigStatusKind::NotConfigured,
+                config: None,
+            },
+            Some(raw) => match serde_json::from_str::<serde_json::Value>(&raw) {
+                Ok(config) => RuntimeConfigStatus {
+                    status: RuntimeConfigStatusKind::Available,
+                    config: Some(config),
+                },
+                Err(error) => {
+                    crate::logger::error!(?error, raw, "Runtime config is invalid");
+                    RuntimeConfigStatus {
+                        status: RuntimeConfigStatusKind::Invalid,
+                        config: None,
+                    }
+                }
+            },
+        }
+    }
+
+    /// Constant-time comparison of a candidate API key against the configured admin key.
+    pub fn verify_admin_api_key(&self, candidate: &str) -> bool {
+        let expected_bytes = self.admin_api_key.peek().as_bytes();
+        let candidate_bytes = candidate.as_bytes();
+        constant_time_eq(expected_bytes, candidate_bytes)
     }
 }
 
-async fn record_runtime_config_fetch_duration(
-    request: reqwest::RequestBuilder,
-) -> Result<reqwest::Response, reqwest::Error> {
-    let start = std::time::Instant::now();
-    let result = request.send().await;
-    let duration = start.elapsed();
-
-    let (outcome, status_code) = match result.as_ref() {
-        Ok(resp) => {
-            let status = resp.status();
-            let outcome = match status.as_u16() {
-                200..=299 => "success",
-                300..=399 => "redirect",
-                400..=499 => "client_error",
-                500..=599 => "server_error",
-                _ => "unknown",
-            };
-            (outcome, Some(status.as_u16()))
-        }
-        Err(_) => ("transport_error", None),
-    };
-
-    let status_code = status_code
-        .map(|s| s.to_string())
-        .unwrap_or_else(|| "UNKNOWN".to_string());
-
-    crate::observability::metrics::RUNTIME_CONFIG_FETCH_DURATION.record(
-        duration.as_secs_f64(),
-        metrics_utils::metric_attributes!(("outcome", outcome), ("status_code", status_code)),
-    );
-
-    result
+fn constant_time_eq(a: &[u8], b: &[u8]) -> bool {
+    if a.len() != b.len() {
+        return false;
+    }
+    let mut diff = 0u8;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
 }

--- a/src/storage.rs
+++ b/src/storage.rs
@@ -12,14 +12,7 @@ pub mod storage_v2;
 pub mod types;
 pub mod utils;
 
-use std::{
-    fmt::Debug,
-    future::Future,
-    sync::{
-        Arc,
-        atomic::{AtomicBool, Ordering},
-    },
-};
+use std::{fmt::Debug, future::Future, sync::Arc};
 
 use diesel_async::{
     AsyncPgConnection,
@@ -30,8 +23,6 @@ use diesel_async::{
 };
 use error_stack::ResultExt;
 use hyperswitch_masking::{PeekInterface, Secret};
-#[cfg(feature = "kv")]
-use tokio::sync::RwLock;
 
 pub use self::scheme::StorageScheme;
 #[cfg(feature = "redis")]
@@ -44,21 +35,24 @@ use crate::{
 
 /// All runtime configs, deserialized directly from the config endpoint's JSON body. Field names
 /// match the keys the endpoint returns; each `#[serde(default)]` field fails closed when absent.
-#[derive(Clone, Debug, Default, serde::Deserialize)]
+#[cfg(feature = "redis")]
+#[derive(Clone, Debug, Default, serde::Deserialize, serde::Serialize)]
 pub struct RuntimeConfigValues {
     #[cfg(feature = "kv")]
     #[serde(default)]
-    enable_kv: kv::KvState,
+    pub enable_kv: kv::KvState,
     #[serde(default)]
-    use_replica: bool,
+    pub use_replica: bool,
 }
 
+#[cfg(feature = "redis")]
 #[derive(Debug, serde::Serialize)]
 pub struct StorageRuntimeConfigStatus {
     pub runtime_config: crate::runtime_config::RuntimeConfigStatus,
     pub storage: StorageRuntimeConfigState,
 }
 
+#[cfg(feature = "redis")]
 #[derive(Debug, serde::Serialize)]
 pub struct StorageRuntimeConfigState {
     pub use_replica: bool,
@@ -66,156 +60,21 @@ pub struct StorageRuntimeConfigState {
     pub kv_state: String,
 }
 
-pub struct GlobalStore {
-    use_replica: AtomicBool,
-    #[cfg(feature = "kv")]
-    config: crate::config::KvConfig,
-    #[cfg(feature = "kv")]
-    kv_state: RwLock<kv::KvState>,
-}
-
-impl GlobalStore {
-    pub fn new(#[cfg(feature = "kv")] config: crate::config::KvConfig) -> Self {
-        Self {
-            use_replica: AtomicBool::new(false),
-            #[cfg(feature = "kv")]
-            config,
-            #[cfg(feature = "kv")]
-            kv_state: RwLock::new(kv::KvState::Disabled),
-        }
-    }
-
-    fn use_replica(&self) -> bool {
-        self.use_replica.load(Ordering::Acquire)
-    }
-
-    fn enable_replica(&self) {
-        self.use_replica.store(true, Ordering::Release);
-    }
-
-    fn disable_replica(&self) {
-        self.use_replica.store(false, Ordering::Release);
-    }
-
-    /// Apply runtime-config replica read transitions after the runtime config cache is refreshed.
-    pub(crate) async fn refresh_replica_state_from_runtime_config<F, Fut>(
-        &self,
-        runtime_config_manager: &crate::runtime_config::RuntimeConfigManager,
-        replica_health_check: F,
-    ) where
-        F: FnOnce() -> Fut,
-        Fut: Future<Output = bool>,
-    {
-        let requested_use_replica = runtime_config_manager
-            .get::<RuntimeConfigValues>()
-            .await
-            .is_some_and(|runtime_conf| runtime_conf.use_replica);
-
-        let current_use_replica = self.use_replica();
-        match (current_use_replica, requested_use_replica) {
-            (false, true) => {
-                if replica_health_check().await {
-                    self.enable_replica();
-                    crate::logger::info!(
-                        storage_runtime_config = "state_refresh",
-                        "Read replica enabled"
-                    );
-                } else {
-                    crate::logger::warn!(
-                        storage_runtime_config = "state_refresh",
-                        "Read replica unavailable"
-                    );
-                }
-            }
-            (true, false) => {
-                self.disable_replica();
-                crate::logger::info!(
-                    storage_runtime_config = "state_refresh",
-                    "Read replica disabled"
-                );
-            }
-            _ => {}
-        }
-    }
-
-    #[cfg(feature = "kv")]
-    async fn kv_state(&self) -> kv::KvState {
-        *self.kv_state.read().await
-    }
-
-    /// Apply runtime-config KV state transitions after the runtime config cache is refreshed.
-    #[cfg(feature = "kv")]
-    pub(crate) async fn refresh_kv_state_from_runtime_config(
-        &self,
-        runtime_config_manager: &crate::runtime_config::RuntimeConfigManager,
-        redis: Option<&redis_store::RedisStore>,
-    ) {
-        let requested_state = runtime_config_manager
-            .get::<RuntimeConfigValues>()
-            .await
-            .map(|runtime_config_values| runtime_config_values.enable_kv)
-            .unwrap_or(kv::KvState::Disabled);
-
-        let current_state = self.kv_state().await;
-        let can_enable_kv = if matches!(
-            (current_state, requested_state),
-            (kv::KvState::Disabled, kv::KvState::Enabled)
-        ) {
-            match redis {
-                Some(redis) => redis
-                    .test()
-                    .await
-                    .inspect_err(|err| {
-                        crate::logger::error!(
-                            storage_runtime_config = "state_refresh",
-                            "error while checking redis connection, Error message: {err:?}",
-                        );
-                    })
-                    .is_ok(),
-                None => {
-                    crate::logger::error!(
-                        storage_runtime_config = "state_refresh",
-                        "Redis connection unavailable"
-                    );
-                    false
-                }
-            }
-        } else {
-            false
-        };
-
-        let mut current_state = self.kv_state.write().await;
-        let next_state = current_state.apply_transition(requested_state, can_enable_kv);
-        if next_state != *current_state {
-            crate::logger::info!(
-                storage_runtime_config = "state_refresh",
-                from = %*current_state,
-                to = %next_state,
-                "KV mode transition accepted"
-            );
-            *current_state = next_state;
-        } else if requested_state != *current_state {
-            crate::logger::warn!(
-                storage_runtime_config = "state_refresh",
-                current = %*current_state,
-                requested = %requested_state,
-                "KV mode transition ignored"
-            );
-        }
-    }
-}
-
 /// Storage State that is to be passed though the application
 #[derive(Clone)]
 pub struct Storage {
     primary_pg_pool: Arc<Pool<AsyncPgConnection>>,
     replica_pg_pool: Option<Arc<Pool<AsyncPgConnection>>>,
-    runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
-    global_store: Arc<GlobalStore>,
-    #[cfg(feature = "redis")]
-    redis: Option<redis_store::TenantAwareRedisStore>,
     #[cfg(feature = "kv")]
     kv_backend: Option<kv::KvBackend>,
+    /// Per-tenant Redis store paired with the runtime-config manager. The manager is
+    /// present only when runtime config is enabled — and it can never exist without
+    /// its Redis read-through cache (enforced in `Storage::new`).
+    #[cfg(feature = "redis")]
+    redis: Option<(
+        redis_store::TenantAwareRedisStore,
+        Option<Arc<crate::runtime_config::RuntimeConfigManager>>,
+    )>,
 }
 
 type DeadPoolConnType = Object<AsyncPgConnection>;
@@ -262,7 +121,18 @@ impl DbConnection {
 impl Storage {
     #[cfg(feature = "redis")]
     pub fn get_redis_store(&self) -> Option<redis_store::TenantAwareRedisStore> {
-        self.redis.clone()
+        self.redis.as_ref().map(|(redis, _)| redis.clone())
+    }
+
+    /// The tenant's runtime-config manager — present only when runtime config is
+    /// enabled (and thereby Redis-configured; see `Storage::new`).
+    #[cfg(feature = "redis")]
+    pub fn runtime_config_manager(
+        &self,
+    ) -> Option<&Arc<crate::runtime_config::RuntimeConfigManager>> {
+        self.redis
+            .as_ref()
+            .and_then(|(_, manager)| manager.as_ref())
     }
     fn create_database_connection_pool(
         database_config: &Database,
@@ -292,14 +162,17 @@ impl Storage {
             .change_context(error::StorageError::DBPoolError)
     }
 
-    /// Create a new storage interface from configuration
+    /// Create a new storage interface from configuration.
+    ///
+    /// Fails when runtime config is enabled but Redis is not configured — the runtime
+    /// config manager is never operated without its Redis read-through cache.
     pub async fn new(
         primary_config: &Database,
         replica_config: Option<&Database>,
         schema: &str,
-        runtime_config_manager: Arc<crate::runtime_config::RuntimeConfigManager>,
-        global_store: Arc<GlobalStore>,
+        #[cfg(feature = "kv")] kv_config: &crate::config::KvConfig,
         #[cfg(feature = "redis")] redis: Option<redis_store::TenantAwareRedisStore>,
+        #[cfg(feature = "redis")] runtime_config: &crate::config::RuntimeConfig,
     ) -> error_stack::Result<Self, error::StorageError> {
         let pg_pool = Arc::new(Self::create_database_connection_pool(
             primary_config,
@@ -313,15 +186,32 @@ impl Storage {
             None => None,
         };
 
+        #[cfg(feature = "redis")]
+        let redis = match redis {
+            Some(redis) => Some((
+                redis,
+                crate::runtime_config::RuntimeConfigManager::new(runtime_config).map(Arc::new),
+            )),
+            None => {
+                if runtime_config.is_enabled() {
+                    return Err(error::StorageError::InitializationError(
+                        "runtime_config is enabled but Redis is not configured",
+                    )
+                    .into());
+                }
+                None
+            }
+        };
+
         Ok(Self {
             primary_pg_pool: pg_pool,
             replica_pg_pool: replica_pool,
-            runtime_config_manager,
-            global_store: global_store.clone(),
-            #[cfg(feature = "redis")]
-            redis: redis.clone(),
             #[cfg(feature = "kv")]
-            kv_backend: redis.map(|redis| kv::KvBackend::redis(redis, global_store.config.clone())),
+            kv_backend: redis
+                .clone()
+                .map(|(redis, _)| kv::KvBackend::redis(redis, kv_config.clone())),
+            #[cfg(feature = "redis")]
+            redis,
         })
     }
 
@@ -360,26 +250,49 @@ impl Storage {
         self.replica_pg_pool.is_some()
     }
 
+    #[cfg(feature = "redis")]
     pub async fn runtime_config_status(&self) -> StorageRuntimeConfigStatus {
+        let runtime_config = match self.runtime_config_manager() {
+            Some(manager) => manager.status(self).await,
+            None => crate::runtime_config::RuntimeConfigStatus {
+                status: crate::runtime_config::RuntimeConfigStatusKind::Disabled,
+                config: None,
+            },
+        };
+
         StorageRuntimeConfigStatus {
-            runtime_config: self.runtime_config_manager.status().await,
+            runtime_config,
             storage: StorageRuntimeConfigState {
-                use_replica: self.global_store.use_replica(),
+                use_replica: self.should_use_replica().await,
                 #[cfg(feature = "kv")]
-                kv_state: self.global_store.kv_state().await.to_string(),
+                kv_state: self.kv_settings().await.to_string(),
             },
         }
     }
 
-    /// Returns `true` when runtime config allows replica reads.
-    fn should_use_replica(&self) -> bool {
-        self.has_replica() && self.global_store.use_replica()
+    /// Returns `true` when the tenant's runtime config enables replica reads and a
+    /// replica pool is configured. Read per-operation from Postgres (`configs` row,
+    /// Redis-cached) — never held in-process. Fails closed (`false`) when the config
+    /// cannot be read.
+    #[cfg(feature = "redis")]
+    async fn should_use_replica(&self) -> bool {
+        self.has_replica()
+            && self
+                .runtime_config_values()
+                .await
+                .is_some_and(|values| values.use_replica)
+    }
+
+    /// Without Redis there is no runtime config at all — replica reads stay off.
+    #[cfg(not(feature = "redis"))]
+    async fn should_use_replica(&self) -> bool {
+        false
     }
 
     /// Returns a connection from the replica pool when the runtime config enables it,
     /// otherwise returns a primary pool connection.
     pub async fn route_conn(&self) -> Result<DbConnection, ContainerError<error::StorageError>> {
-        if self.should_use_replica() {
+        if self.should_use_replica().await {
             crate::logger::debug!("Routing to read replica");
             self.get_replica_conn().await
         } else {
@@ -388,10 +301,29 @@ impl Storage {
         }
     }
 
-    /// Return the current KV state cached by the runtime-config poller.
+    /// Read the KV state from the tenant's runtime config (`configs` Postgres row,
+    /// read-through the tenant's Redis cache). Fails closed to `Disabled` when the
+    /// config cannot be read.
     #[cfg(feature = "kv")]
     pub(crate) async fn kv_settings(&self) -> kv::KvState {
-        self.global_store.kv_state().await
+        self.runtime_config_values()
+            .await
+            .map(|values| values.enable_kv)
+            .unwrap_or(kv::KvState::Disabled)
+    }
+
+    /// Fetch the tenant's runtime-config values via the runtime-config manager
+    /// (`configs` Postgres row, read-through the tenant's Redis cache).
+    ///
+    /// **No fetch happens when runtime config is disabled** — there is no manager, so
+    /// `None` is returned and callers fail closed (`use_replica: false`, KV `Disabled`)
+    /// without touching Postgres or Redis.
+    #[cfg(feature = "redis")]
+    pub(crate) async fn runtime_config_values(&self) -> Option<RuntimeConfigValues> {
+        match self.runtime_config_manager() {
+            Some(manager) => manager.get::<RuntimeConfigValues>(self).await,
+            None => None,
+        }
     }
 
     #[cfg(feature = "kv")]
@@ -633,6 +565,29 @@ pub(crate) trait ReverseLookupInterface {
 }
 
 ///
+/// ConfigInterface:
+///
+/// Interface for interacting with the `configs` database table — the source of
+/// truth for runtime configuration (`use_replica`, `enable_kv`).
+#[cfg(feature = "redis")]
+pub(crate) trait ConfigInterface {
+    type Error;
+
+    /// Read a config row by its primary key. Returns `None` when the row is absent.
+    async fn find_config(
+        &self,
+        key: &str,
+    ) -> Result<Option<serde_json::Value>, ContainerError<Self::Error>>;
+
+    /// Upsert a config row (`INSERT … ON CONFLICT (key) DO UPDATE`).
+    async fn upsert_config(
+        &self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Result<(), ContainerError<Self::Error>>;
+}
+
+///
 /// EntityInterface:
 ///
 /// Interface providing functionality to interface with the entity table in database
@@ -744,7 +699,6 @@ where
     result
 }
 
-#[cfg_attr(feature = "kv", expect(dead_code))]
 async fn record_db_query_optional<T, Fut, R, E>(
     future: Fut,
     operation: DbOperation,

--- a/src/storage/consts.rs
+++ b/src/storage/consts.rs
@@ -25,6 +25,17 @@ pub const REDIS_HEALTH_CHECK_VALUE: &str = "1";
 #[cfg(feature = "redis")]
 pub const REDIS_HEALTH_CHECK_EXPIRY: i64 = 5;
 
+/// TTL (seconds) for the runtime-config Redis cache entry. Bounds staleness when an
+/// invalidate-on-update `DEL` fails (e.g., transient Redis outage).
+#[cfg(feature = "redis")]
+pub const RUNTIME_CONFIG_REDIS_TTL_SECS: i64 = 3600;
+
+/// The key identifying the runtime config — used both as the primary-key value in the
+/// `configs` Postgres table and as the Redis cache key (per-tenant prefix added by
+/// `TenantAwareRedisStore`).
+#[cfg(feature = "redis")]
+pub const RUNTIME_CONFIG_KEY: &str = "locker_runtime_config";
+
 /// Header Constants
 pub mod headers {
     pub const CONTENT_TYPE: &str = "Content-Type";

--- a/src/storage/db.rs
+++ b/src/storage/db.rs
@@ -1,6 +1,6 @@
 #[cfg(not(feature = "kv"))]
-use diesel::{BoolExpressionMethods, OptionalExtension};
-use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
+use diesel::BoolExpressionMethods;
+use diesel::{ExpressionMethods, OptionalExtension, QueryDsl, associations::HasTable};
 use diesel_async::{AsyncConnection, RunQueryDsl};
 #[cfg(not(feature = "kv"))]
 use hyperswitch_masking::ExposeInterface;
@@ -686,5 +686,81 @@ impl super::ReverseLookupInterface for Storage {
             .await?;
             Ok(output)
         }
+    }
+}
+
+#[cfg(feature = "redis")]
+impl super::ConfigInterface for Storage {
+    type Error = error::RuntimeConfigError;
+
+    async fn find_config(
+        &self,
+        key: &str,
+    ) -> Result<Option<serde_json::Value>, ContainerError<Self::Error>> {
+        // Config reads always use the primary pool — the value must be current,
+        // and the table is tiny (single-row lookup by PK).
+        let mut conn = self
+            .get_conn()
+            .await
+            .change_error(error::RuntimeConfigError::StorageError)?;
+
+        let query = types::Config::table().filter(schema::configs::key.eq(key));
+
+        let pool = conn.pool();
+        let operation = DbOperation::FindOne;
+        super::log_db_query::<<types::Config as HasTable>::Table, _>(&query, operation, pool);
+
+        let result =
+            super::record_db_query_optional::<<types::Config as HasTable>::Table, _, _, _>(
+                async {
+                    query
+                        .get_result::<types::Config>(conn.get_mut())
+                        .await
+                        .optional()
+                },
+                operation,
+                pool,
+            )
+            .await?;
+
+        Ok(result.map(|config| config.value))
+    }
+
+    async fn upsert_config(
+        &self,
+        key: &str,
+        value: serde_json::Value,
+    ) -> Result<(), ContainerError<Self::Error>> {
+        let mut conn = self
+            .get_conn()
+            .await
+            .change_error(error::RuntimeConfigError::StorageError)?;
+        let now = crate::utils::date_time::now();
+        let new_config = types::ConfigNew {
+            key: key.to_string(),
+            value,
+            created_at: now,
+            updated_at: now,
+        };
+        let update = types::ConfigUpdate::from(new_config.clone());
+
+        let query = diesel::insert_into(types::Config::table())
+            .values(&new_config)
+            .on_conflict(schema::configs::key)
+            .do_update()
+            .set(update);
+
+        let pool = conn.pool();
+        let operation = DbOperation::Insert;
+        super::log_db_query::<<types::Config as HasTable>::Table, _>(&query, operation, pool);
+
+        super::record_db_query_rows::<<types::Config as HasTable>::Table, _, _>(
+            query.execute(conn.get_mut()),
+            operation,
+            pool,
+        )
+        .await?;
+
+        Ok(())
     }
 }

--- a/src/storage/kv.rs
+++ b/src/storage/kv.rs
@@ -7,10 +7,12 @@ pub(crate) mod impls;
 pub(crate) mod partition_key;
 #[cfg(feature = "kv")]
 pub(crate) mod resource;
-pub(crate) mod scheme;
+pub mod scheme;
 pub(crate) mod serializable_query;
 pub(crate) mod wrapper;
 
+pub use self::scheme::KvState;
+pub(crate) use self::wrapper::KvBackend;
 #[cfg(feature = "kv")]
 pub(crate) use self::{
     partition_key::PartitionKey,
@@ -20,5 +22,4 @@ pub(crate) use self::{
         insert_resource, insert_resource_with_reverse_lookup, update_resource_by_id,
     },
 };
-pub(crate) use self::{scheme::KvState, wrapper::KvBackend};
 pub(crate) use super::scheme::StorageScheme;

--- a/src/storage/kv/scheme.rs
+++ b/src/storage/kv/scheme.rs
@@ -2,10 +2,12 @@
 ///
 /// `ttl_for_kv` must exceed max drainer replay lag — otherwise a KV-only
 /// fingerprint can expire in Redis before reaching Postgres.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, strum::Display)]
+#[derive(
+    Debug, Clone, Copy, PartialEq, Eq, Default, serde::Deserialize, serde::Serialize, strum::Display,
+)]
 #[serde(rename_all = "snake_case")]
 #[strum(serialize_all = "snake_case")]
-pub(crate) enum KvState {
+pub enum KvState {
     #[default]
     Disabled,
     /// Write-through Redis; drainer replays to Postgres.
@@ -14,8 +16,17 @@ pub(crate) enum KvState {
     SoftKill,
 }
 
+/// Transitions are enforced at the runtime-config write path (`POST /runtime-config`)
+/// by comparing the persisted (previous) state against the requested state — the KV
+/// state itself is never held in-process, only read from Postgres/Redis per operation.
 impl KvState {
-    pub(crate) fn apply_transition(self, requested: Self, can_enable_kv: bool) -> Self {
+    /// Validate a requested state transition. `can_enable_kv` is `true` when the KV
+    /// backend (Redis) is confirmed reachable — required to leave `Disabled`.
+    pub(crate) fn is_valid_transition(self, requested: Self, can_enable_kv: bool) -> bool {
+        self.apply_candidate(requested, can_enable_kv) == requested
+    }
+
+    fn apply_candidate(self, requested: Self, can_enable_kv: bool) -> Self {
         match (self, requested) {
             (current, requested) if current == requested => current,
             (Self::Disabled, Self::Enabled) if can_enable_kv => Self::Enabled,
@@ -31,42 +42,22 @@ mod tests {
     use super::KvState;
 
     #[test]
-    fn applies_allowed_kv_state_transitions() {
-        assert_eq!(
-            KvState::Disabled.apply_transition(KvState::Enabled, true),
-            KvState::Enabled
-        );
-        assert_eq!(
-            KvState::Enabled.apply_transition(KvState::SoftKill, false),
-            KvState::SoftKill
-        );
-        assert_eq!(
-            KvState::SoftKill.apply_transition(KvState::Disabled, false),
-            KvState::Disabled
-        );
+    fn allows_valid_kv_state_transitions() {
+        assert!(KvState::Disabled.is_valid_transition(KvState::Enabled, true));
+        assert!(KvState::Enabled.is_valid_transition(KvState::SoftKill, false));
+        assert!(KvState::SoftKill.is_valid_transition(KvState::Disabled, false));
+        assert!(KvState::Enabled.is_valid_transition(KvState::Enabled, false));
     }
 
     #[test]
-    fn ignores_disabled_to_enabled_without_redis() {
-        assert_eq!(
-            KvState::Disabled.apply_transition(KvState::Enabled, false),
-            KvState::Disabled
-        );
+    fn rejects_disabled_to_enabled_without_redis() {
+        assert!(!KvState::Disabled.is_valid_transition(KvState::Enabled, false));
     }
 
     #[test]
-    fn ignores_unsupported_kv_state_transitions() {
-        assert_eq!(
-            KvState::Disabled.apply_transition(KvState::SoftKill, true),
-            KvState::Disabled
-        );
-        assert_eq!(
-            KvState::Enabled.apply_transition(KvState::Disabled, true),
-            KvState::Enabled
-        );
-        assert_eq!(
-            KvState::SoftKill.apply_transition(KvState::Enabled, true),
-            KvState::SoftKill
-        );
+    fn rejects_unsupported_kv_state_transitions() {
+        assert!(!KvState::Disabled.is_valid_transition(KvState::SoftKill, true));
+        assert!(!KvState::Enabled.is_valid_transition(KvState::Disabled, true));
+        assert!(!KvState::SoftKill.is_valid_transition(KvState::Enabled, true));
     }
 }

--- a/src/storage/redis.rs
+++ b/src/storage/redis.rs
@@ -1,4 +1,4 @@
-use std::sync::Arc;
+use std::{future::Future, sync::Arc};
 
 use hyperswitch_redis_interface::{RedisConnectionPool, RedisSettings, errors::RedisError};
 use tracing::Instrument;
@@ -91,5 +91,72 @@ impl RedisStore {
         }
         redis_conn.delete_key(&key).await.map_err(into_report)?;
         Ok(())
+    }
+
+    /// Read-through cache helper.
+    ///
+    /// Tries `GET key` first; on a hit returns the cached string immediately.
+    /// On a miss (or Redis error — fail-open) it calls `fetch` to produce the
+    /// value, then best-effort populates Redis with `SETEX key ttl value`
+    /// so subsequent reads hit the cache. Returns `None` when both Redis and
+    /// the `fetch` fallback yield nothing.
+    pub(crate) async fn get_or_populate<F, Fut>(
+        &self,
+        key: &str,
+        ttl_secs: i64,
+        fetch: F,
+    ) -> Option<String>
+    where
+        F: FnOnce() -> Fut + Send,
+        Fut: Future<Output = Option<String>> + Send,
+    {
+        let redis_conn = self.get_redis_conn();
+        let redis_key = key.into();
+
+        match redis_conn.get_key::<Option<String>>(&redis_key).await {
+            Ok(Some(value)) => {
+                crate::logger::debug!(redis_key = %key, "Runtime config cache hit");
+                return Some(value);
+            }
+            Ok(None) => {
+                crate::logger::debug!(redis_key = %key, "Runtime config cache miss");
+            }
+            Err(err) => {
+                crate::logger::warn!(
+                    ?err,
+                    redis_key = %key,
+                    "Redis GET failed for runtime config, falling back to fetch"
+                );
+            }
+        }
+
+        let value = fetch().await?;
+
+        if let Err(err) = redis_conn
+            .set_key_with_expiry(&redis_key, value.clone(), ttl_secs)
+            .await
+        {
+            crate::logger::warn!(
+                ?err,
+                redis_key = %key,
+                "Failed to populate Redis cache for runtime config"
+            );
+        }
+
+        Some(value)
+    }
+
+    /// Invalidate (DEL) a cached key. The Redis TTL bounds staleness if this
+    /// fails, so errors are logged as warnings rather than propagated.
+    pub(crate) async fn invalidate(&self, key: &str) {
+        let redis_conn = self.get_redis_conn();
+        let redis_key = key.into();
+        if let Err(err) = redis_conn.delete_key(&redis_key).await {
+            crate::logger::warn!(
+                ?err,
+                redis_key = %key,
+                "Failed to invalidate Redis cache for runtime config; TTL bounds staleness"
+            );
+        }
     }
 }

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -5,8 +5,8 @@ diesel::table! {
         #[max_length = 255]
         key -> Varchar,
         value -> Jsonb,
-        updated_at -> Timestamp,
         created_at -> Timestamp,
+        updated_at -> Timestamp,
     }
 }
 

--- a/src/storage/schema.rs
+++ b/src/storage/schema.rs
@@ -1,6 +1,16 @@
 // @generated automatically by Diesel CLI.
 
 diesel::table! {
+    configs (key) {
+        #[max_length = 255]
+        key -> Varchar,
+        value -> Jsonb,
+        updated_at -> Timestamp,
+        created_at -> Timestamp,
+    }
+}
+
+diesel::table! {
     entity (entity_id) {
         id -> Int4,
         #[max_length = 255]
@@ -90,6 +100,7 @@ diesel::table! {
 }
 
 diesel::allow_tables_to_appear_in_same_query!(
+    configs,
     entity,
     fingerprint,
     hash_table,

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -1,6 +1,6 @@
 use base64::Engine;
 use diesel::{
-    AsExpression, Identifiable, Insertable, Queryable,
+    AsChangeset, AsExpression, Identifiable, Insertable, Queryable,
     backend::Backend,
     deserialize::{self, FromSql},
     serialize::ToSql,
@@ -184,6 +184,43 @@ impl From<LockerNew> for Locker {
             hash_id: value.hash_id,
             ttl: value.ttl,
             updated_by: value.updated_by,
+        }
+    }
+}
+
+#[derive(Debug, Clone, Identifiable, Queryable)]
+#[diesel(table_name = schema::configs, primary_key(key))]
+#[allow(dead_code)]
+pub(crate) struct Config {
+    pub key: String,
+    pub value: serde_json::Value,
+    pub updated_at: time::PrimitiveDateTime,
+    pub created_at: time::PrimitiveDateTime,
+}
+
+#[derive(Debug, Clone, Insertable)]
+#[diesel(table_name = schema::configs)]
+pub(crate) struct ConfigNew {
+    pub key: String,
+    pub value: serde_json::Value,
+    pub created_at: time::PrimitiveDateTime,
+    pub updated_at: time::PrimitiveDateTime,
+}
+
+/// Updatable fields of a `configs` row — used by `ON CONFLICT … DO UPDATE`
+/// so `key` and `created_at` are never rewritten.
+#[derive(Debug, Clone, AsChangeset)]
+#[diesel(table_name = schema::configs, primary_key(key))]
+pub(crate) struct ConfigUpdate {
+    pub value: serde_json::Value,
+    pub updated_at: time::PrimitiveDateTime,
+}
+
+impl From<ConfigNew> for ConfigUpdate {
+    fn from(value: ConfigNew) -> Self {
+        Self {
+            value: value.value,
+            updated_at: value.updated_at,
         }
     }
 }

--- a/src/storage/types.rs
+++ b/src/storage/types.rs
@@ -194,8 +194,8 @@ impl From<LockerNew> for Locker {
 pub(crate) struct Config {
     pub key: String,
     pub value: serde_json::Value,
-    pub updated_at: time::PrimitiveDateTime,
     pub created_at: time::PrimitiveDateTime,
+    pub updated_at: time::PrimitiveDateTime,
 }
 
 #[derive(Debug, Clone, Insertable)]

--- a/src/tenant.rs
+++ b/src/tenant.rs
@@ -7,10 +7,9 @@ use tokio::sync::RwLock;
 use crate::config::TenantConfig;
 #[cfg(feature = "key_custodian")]
 use crate::routes::key_custodian::CustodianKeyState;
-use crate::{
-    api_client::ApiClient, app::TenantAppState, config::GlobalConfig, error::ApiError, logger,
-    runtime_config::RuntimeConfigManager,
-};
+#[cfg(feature = "redis")]
+use crate::runtime_config::RuntimeConfigManager;
+use crate::{api_client::ApiClient, app::TenantAppState, config::GlobalConfig, error::ApiError};
 
 pub struct GlobalAppState {
     pub tenants_app_state: RwLock<FxHashMap<String, Arc<TenantAppState>>>,
@@ -21,8 +20,6 @@ pub struct GlobalAppState {
     pub global_config: GlobalConfig,
     #[cfg(feature = "redis")]
     pub redis_store: Option<crate::storage::redis::RedisStore>,
-    pub storage_global_store: Arc<crate::storage::GlobalStore>,
-    pub runtime_config_manager: Arc<RuntimeConfigManager>,
 }
 
 impl GlobalAppState {
@@ -66,21 +63,6 @@ impl GlobalAppState {
             None => None,
         };
 
-        #[allow(clippy::expect_used)]
-        let runtime_config_manager = Arc::new(
-            RuntimeConfigManager::new(
-                &global_config.runtime_config,
-                global_config.api_client.client_idle_timeout,
-                global_config.api_client.pool_max_idle_per_host,
-            )
-            .expect("Failed to create runtime config manager"),
-        );
-
-        let storage_global_store = Arc::new(crate::storage::GlobalStore::new(
-            #[cfg(feature = "kv")]
-            global_config.kv.clone(),
-        ));
-
         let tenants_app_state = {
             #[cfg(feature = "key_custodian")]
             {
@@ -99,8 +81,6 @@ impl GlobalAppState {
                         api_client.clone(),
                         #[cfg(feature = "redis")]
                         redis_store.as_ref(),
-                        runtime_config_manager.clone(),
-                        storage_global_store.clone(),
                     )
                     .await
                     .expect("Failed while configuring AppState for tenants");
@@ -119,8 +99,6 @@ impl GlobalAppState {
             global_config,
             #[cfg(feature = "redis")]
             redis_store,
-            storage_global_store,
-            runtime_config_manager,
         })
     }
 
@@ -148,36 +126,17 @@ impl GlobalAppState {
         write_guard.insert(state.config.tenant_id.clone(), Arc::new(state));
     }
 
-    pub async fn apply_runtime_config_updates(&self) {
-        #[cfg(feature = "kv")]
-        {
-            self.storage_global_store
-                .refresh_kv_state_from_runtime_config(
-                    &self.runtime_config_manager,
-                    self.redis_store.as_ref(),
-                )
-                .await;
-        }
-
-        self.storage_global_store
-            .refresh_replica_state_from_runtime_config(&self.runtime_config_manager, || async {
-                // `use_replica` is global, but replica availability is verified through a
-                // tenant `Storage` because the replica pool is owned there. The health check is
-                // evaluated lazily only when runtime config tries to enable replica reads.
-                let tenant_app_state = self.tenants_app_state.read().await.values().next().cloned();
-                match tenant_app_state {
-                    Some(tenant_app_state) => tenant_app_state
-                        .db
-                        .get_replica_conn()
-                        .await
-                        .inspect_err(|err| {
-                            logger::error!("Error while checking read replica connection: {}", err)
-                        })
-                        .is_ok(),
-                    None => false,
-                }
-            })
-            .await;
+    /// Fetch the runtime config manager for a given tenant, if the tenant is known.
+    #[cfg(feature = "redis")]
+    pub async fn get_runtime_config_manager(
+        &self,
+        tenant_id: &str,
+    ) -> Option<Arc<RuntimeConfigManager>> {
+        self.tenants_app_state
+            .read()
+            .await
+            .get(tenant_id)
+            .and_then(|state| state.db.runtime_config_manager().cloned())
     }
 
     #[cfg(feature = "key_custodian")]


### PR DESCRIPTION
## Summary

Replaces HTTP-polling runtime configuration with a per-tenant store backed by Postgres as the source of truth and a read-through Redis cache. Removes polling, adds an authenticated admin endpoint for updates, and tolerates Redis failures (bounded by TTL).

- **Source of truth**: new `configs` table per tenant schema (migration `2026-08-17-120000_create_configs_table`)
- **Cache**: per-tenant Redis entry with TTL; on miss or error, falls back to Postgres and re-populates best-effort
- **Bootstrap**: on startup, if the row is missing, seeds `{ "use_replica": false, "enable_kv": "disabled" }` and applies the resulting KV / replica transitions
- **Admin endpoint**: `POST /runtime-config` guarded by `x-internal-api-key`, plus existing `GET /health/runtime-config` for read-only checks
- **Config surface**: all `runtime_config.endpoint.*` TOML keys removed; the only knob is `runtime_config.admin_api_key` (env: `LOCKER__RUNTIME_CONFIG__ADMIN_API_KEY`)

## Admin endpoint

```
POST /runtime-config
Headers:
  x-tenant-id: <tenant>
  x-internal-api-key: <admin_api_key>
Body:
  {"value": {"use_replica": true, "enable_kv": "enabled"}}
```

Upserts Postgres (source of truth), invalidates the tenant's Redis cache key (`DEL` — TTL bounds staleness on failure), and applies KV / replica state transitions.

## Notable implementation points

- New `ConfigInterface` trait on `Storage` with `find_config` / `upsert_config`; `type Error = RuntimeConfigError` so callers get already-classified errors
- New `ConfigUpdate` (AsChangeset) restricts `ON CONFLICT` writes to `value` and `updated_at` — never rewrites `key` or `created_at`
- `impl_storage_error!` macro invocation for `RuntimeConfigError` maps raw diesel errors (`NotFound` / unique-violation / other) onto enum variants
- Runtime config manager holds no storage handle; `&Storage` is passed into each method so the same pool serves reads and writes

## Migration

Single squashed migration `2026-08-17-120000_create_configs_table`:
- `key VARCHAR(255) PRIMARY KEY`
- `value JSONB NOT NULL`
- `created_at / updated_at TIMESTAMP NOT NULL` (application-populated, no DB defaults)

## Test plan

- [ ] `cargo check --all-features` and `cargo clippy --all-features --lib` clean
- [ ] Boot with `runtime_config.mode = "enabled"` and no row: service seeds default and applies `enable_kv=disabled`, `use_replica=false`
- [ ] `POST /runtime-config` with valid key updates Postgres, invalidates Redis, transitions take effect immediately (no polling lag)
- [ ] `POST /runtime-config` with invalid key returns 401
- [ ] `GET /health/runtime-config` reflects the current state
- [ ] Redis down: reads fall back to Postgres; writes still succeed and are visible on next read
- [ ] Revert migration `down.sql` cleanly removes the table

## Breaking changes

All `runtime_config.endpoint.*` config keys are replaced with a single `runtime_config.admin_api_key`. Operators previously pointing at a remote config endpoint must migrate to the admin endpoint flow.