### PR TITLE
refactor(kv): collect drainer binds via live pooled connection

### DIFF
--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -7,7 +7,7 @@ use hyperswitch_masking::{PeekInterface, Secret};
 use crate::{
     error::{ContainerError, FingerprintDBError, kv::KvError},
     storage::{
-        DbOperation, Storage,
+        DbOperation, PgPooledConn, Storage,
         kv::{
             PartitionKey, StorageScheme,
             entity::EntityType,
@@ -70,11 +70,11 @@ impl KvResource for Fingerprint {
     }
 
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         generate_insert_query::<crate::storage::schema::fingerprint::table, _>(
-            store,
+            conn,
             new_object.clone(),
         )
         .await

--- a/src/storage/kv/impls/fingerprint.rs
+++ b/src/storage/kv/impls/fingerprint.rs
@@ -69,10 +69,15 @@ impl KvResource for Fingerprint {
         new_object.updated_by = Some(scheme);
     }
 
-    fn generate_insert_drainer_query(
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
-        generate_insert_query::<crate::storage::schema::fingerprint::table, _>(new_object.clone())
+        generate_insert_query::<crate::storage::schema::fingerprint::table, _>(
+            store,
+            new_object.clone(),
+        )
+        .await
     }
 
     async fn storage_insert(

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -5,7 +5,7 @@ use hyperswitch_masking::Secret;
 use crate::{
     error::{ContainerError, HashDBError, kv::KvError},
     storage::{
-        DbOperation, Storage,
+        DbOperation, PgPooledConn, Storage,
         kv::{
             StorageScheme,
             entity::EntityType,
@@ -67,11 +67,11 @@ impl KvResource for HashTable {
     }
 
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         generate_insert_query::<crate::storage::schema::hash_table::table, _>(
-            store,
+            conn,
             new_object.clone(),
         )
         .await

--- a/src/storage/kv/impls/hash_table.rs
+++ b/src/storage/kv/impls/hash_table.rs
@@ -66,10 +66,15 @@ impl KvResource for HashTable {
         new_object.updated_by = Some(scheme);
     }
 
-    fn generate_insert_drainer_query(
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
-        generate_insert_query::<crate::storage::schema::hash_table::table, _>(new_object.clone())
+        generate_insert_query::<crate::storage::schema::hash_table::table, _>(
+            store,
+            new_object.clone(),
+        )
+        .await
     }
 
     async fn storage_insert(

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -154,10 +154,12 @@ impl KvResource for Locker {
         new_object.updated_by = Some(scheme);
     }
 
-    fn generate_insert_drainer_query(
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
-        generate_insert_query::<crate::storage::schema::locker::table, _>(new_object.clone())
+        generate_insert_query::<crate::storage::schema::locker::table, _>(store, new_object.clone())
+            .await
     }
 
     async fn storage_insert(
@@ -217,7 +219,8 @@ impl KvResource for Locker {
 }
 
 impl KvDeletableResource for Locker {
-    fn generate_delete_drainer_query(
+    async fn generate_delete_drainer_query(
+        store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
         let query = diesel::delete(crate::storage::schema::locker::table).filter(
@@ -227,7 +230,7 @@ impl KvDeletableResource for Locker {
                 .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id.clone())),
         );
 
-        generate_delete_query::<_, Self>(query)
+        generate_delete_query::<_, Self>(store, query).await
     }
 
     async fn storage_delete(

--- a/src/storage/kv/impls/locker.rs
+++ b/src/storage/kv/impls/locker.rs
@@ -5,7 +5,7 @@ use hyperswitch_masking::PeekInterface;
 use crate::{
     error::{ContainerError, VaultDBError},
     storage::{
-        DbOperation, Storage,
+        DbOperation, PgPooledConn, Storage,
         kv::{
             StorageScheme,
             entity::EntityType,
@@ -155,10 +155,10 @@ impl KvResource for Locker {
     }
 
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
-        generate_insert_query::<crate::storage::schema::locker::table, _>(store, new_object.clone())
+        generate_insert_query::<crate::storage::schema::locker::table, _>(conn, new_object.clone())
             .await
     }
 
@@ -220,7 +220,7 @@ impl KvResource for Locker {
 
 impl KvDeletableResource for Locker {
     async fn generate_delete_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
         let query = diesel::delete(crate::storage::schema::locker::table).filter(
@@ -230,7 +230,7 @@ impl KvDeletableResource for Locker {
                 .and(crate::storage::schema::locker::customer_id.eq(pk.customer_id.clone())),
         );
 
-        generate_delete_query::<_, Self>(store, query).await
+        generate_delete_query::<_, Self>(conn, query).await
     }
 
     async fn storage_delete(

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -69,12 +69,15 @@ impl KvResource for ReverseLookup {
         new_object.updated_by = scheme.to_string();
     }
 
-    fn generate_insert_drainer_query(
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         generate_insert_query::<crate::storage::schema::reverse_lookup::table, _>(
+            store,
             new_object.clone(),
         )
+        .await
     }
 
     async fn storage_insert(
@@ -120,13 +123,14 @@ impl KvResource for ReverseLookup {
 }
 
 impl KvDeletableResource for ReverseLookup {
-    fn generate_delete_drainer_query(
+    async fn generate_delete_drainer_query(
+        store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         let query = diesel::delete(crate::storage::schema::reverse_lookup::table)
             .filter(crate::storage::schema::reverse_lookup::lookup_id.eq(pk.lookup_id.clone()));
 
-        generate_delete_query::<_, Self>(query)
+        generate_delete_query::<_, Self>(store, query).await
     }
 
     async fn storage_delete(

--- a/src/storage/kv/impls/reverse_lookup.rs
+++ b/src/storage/kv/impls/reverse_lookup.rs
@@ -4,7 +4,7 @@ use diesel::{ExpressionMethods, QueryDsl, associations::HasTable};
 use crate::{
     error::{ContainerError, ReverseLookupDBError, kv::KvError},
     storage::{
-        self, Storage,
+        self, PgPooledConn, Storage,
         kv::{
             StorageScheme,
             entity::EntityType,
@@ -70,11 +70,11 @@ impl KvResource for ReverseLookup {
     }
 
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         generate_insert_query::<crate::storage::schema::reverse_lookup::table, _>(
-            store,
+            conn,
             new_object.clone(),
         )
         .await
@@ -124,13 +124,13 @@ impl KvResource for ReverseLookup {
 
 impl KvDeletableResource for ReverseLookup {
     async fn generate_delete_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError> {
         let query = diesel::delete(crate::storage::schema::reverse_lookup::table)
             .filter(crate::storage::schema::reverse_lookup::lookup_id.eq(pk.lookup_id.clone()));
 
-        generate_delete_query::<_, Self>(store, query).await
+        generate_delete_query::<_, Self>(conn, query).await
     }
 
     async fn storage_delete(

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -5,7 +5,7 @@ use hyperswitch_masking::PeekInterface;
 use crate::{
     error::{ContainerError, VaultDBError},
     storage::{
-        DbOperation, Storage,
+        DbOperation, PgPooledConn, Storage,
         kv::{
             StorageScheme,
             entity::EntityType,
@@ -84,10 +84,10 @@ impl KvResource for Vault {
     }
 
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
-        generate_insert_query::<crate::storage::schema::vault::table, _>(store, new_object.clone())
+        generate_insert_query::<crate::storage::schema::vault::table, _>(conn, new_object.clone())
             .await
     }
 
@@ -140,7 +140,7 @@ impl KvResource for Vault {
 
 impl KvDeletableResource for Vault {
     async fn generate_delete_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
         let query = diesel::delete(crate::storage::schema::vault::table).filter(
@@ -149,7 +149,7 @@ impl KvDeletableResource for Vault {
                 .and(crate::storage::schema::vault::entity_id.eq(pk.entity_id.clone())),
         );
 
-        generate_delete_query::<_, Self::DieselEntity>(store, query).await
+        generate_delete_query::<_, Self::DieselEntity>(conn, query).await
     }
 
     async fn storage_delete(
@@ -187,7 +187,7 @@ impl KvUpdatableResource for Vault {
     }
 
     async fn generate_update_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         update: &Self::DieselUpdate,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
@@ -199,7 +199,7 @@ impl KvUpdatableResource for Vault {
             )
             .set(update.clone());
 
-        generate_update_query::<_, Self::DieselEntity>(store, query).await
+        generate_update_query::<_, Self::DieselEntity>(conn, query).await
     }
 
     fn apply_update(update: Self::DieselUpdate, current: Self::DieselEntity) -> Self::DieselEntity {

--- a/src/storage/kv/impls/vault.rs
+++ b/src/storage/kv/impls/vault.rs
@@ -83,10 +83,12 @@ impl KvResource for Vault {
         new_object.set_updated_by(scheme);
     }
 
-    fn generate_insert_drainer_query(
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
-        generate_insert_query::<crate::storage::schema::vault::table, _>(new_object.clone())
+        generate_insert_query::<crate::storage::schema::vault::table, _>(store, new_object.clone())
+            .await
     }
 
     async fn storage_insert(
@@ -137,7 +139,8 @@ impl KvResource for Vault {
 }
 
 impl KvDeletableResource for Vault {
-    fn generate_delete_drainer_query(
+    async fn generate_delete_drainer_query(
+        store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
         let query = diesel::delete(crate::storage::schema::vault::table).filter(
@@ -146,7 +149,7 @@ impl KvDeletableResource for Vault {
                 .and(crate::storage::schema::vault::entity_id.eq(pk.entity_id.clone())),
         );
 
-        generate_delete_query::<_, Self::DieselEntity>(query)
+        generate_delete_query::<_, Self::DieselEntity>(store, query).await
     }
 
     async fn storage_delete(
@@ -183,7 +186,8 @@ impl KvUpdatableResource for Vault {
         update.updated_by = scheme;
     }
 
-    fn generate_update_drainer_query(
+    async fn generate_update_drainer_query(
+        store: &Storage,
         update: &Self::DieselUpdate,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, crate::error::kv::KvError> {
@@ -195,7 +199,7 @@ impl KvUpdatableResource for Vault {
             )
             .set(update.clone());
 
-        generate_update_query::<_, Self::DieselEntity>(query)
+        generate_update_query::<_, Self::DieselEntity>(store, query).await
     }
 
     fn apply_update(update: Self::DieselUpdate, current: Self::DieselEntity) -> Self::DieselEntity {

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -123,7 +123,10 @@ pub(crate) trait KvResource:
 
     /// Build the INSERT statement consumed by the drainer when Redis is the
     /// write path.
-    fn generate_insert_drainer_query(
+    ///
+    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    async fn generate_insert_drainer_query(
+        store: &Storage,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError>;
 
@@ -155,7 +158,10 @@ pub(crate) trait KvResource:
 pub(crate) trait KvDeletableResource: KvResource {
     /// Build the DELETE statement consumed by the drainer when Redis is the
     /// delete path.
-    fn generate_delete_drainer_query(
+    ///
+    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    async fn generate_delete_drainer_query(
+        store: &Storage,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError>;
 
@@ -190,7 +196,10 @@ pub(crate) trait KvUpdatableResource: KvResource {
 
     /// Build the UPDATE statement consumed by the drainer when Redis is the
     /// update path.
-    fn generate_update_drainer_query(
+    ///
+    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    async fn generate_update_drainer_query(
+        store: &Storage,
         update: &Self::DieselUpdate,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError>;
@@ -871,7 +880,8 @@ where
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_insert(diesel_new, store).await,
         DecidedStorageScheme::Kv(kv_backend) => {
-            let drainer_query = M::generate_insert_drainer_query(&diesel_new)
+            let drainer_query = M::generate_insert_drainer_query(store, &diesel_new)
+                .await
                 .map_err(kv_backend_error::<M::Error>)?;
 
             let partition_key_str = partition_key.to_string();
@@ -1141,7 +1151,8 @@ where
                 Some(resource) => resource,
                 None => find_resource_by_id_inner::<M>(store, primary_key.clone()).await?,
             };
-            let update_query = M::generate_update_drainer_query(&update, &primary_key)
+            let update_query = M::generate_update_drainer_query(store, &update, &primary_key)
+                .await
                 .map_err(kv_backend_error::<M::Error>)?;
             let updated_model = M::apply_update(update, current);
             let updated_resource = updated_model.clone().into();
@@ -1187,7 +1198,8 @@ where
         DecidedStorageScheme::Kv(kv_backend) => {
             let partition_key = primary_key.get_partition_key();
             let secondary_key = primary_key.get_secondary_key();
-            let delete_query = M::generate_delete_drainer_query(&primary_key)
+            let delete_query = M::generate_delete_drainer_query(store, &primary_key)
+                .await
                 .map_err(kv_backend_error::<M::Error>)?;
 
             let partition_key_str = partition_key.to_string();

--- a/src/storage/kv/resource.rs
+++ b/src/storage/kv/resource.rs
@@ -20,7 +20,7 @@ use crate::{
         kv::{KvError, RedisErrorExt},
     },
     observability::metrics,
-    storage::{ReverseLookupInterface, Storage, types},
+    storage::{DbConnection, PgPooledConn, ReverseLookupInterface, Storage, types},
 };
 
 /// Trait for retrieving the partition key of a KV resource.
@@ -124,9 +124,9 @@ pub(crate) trait KvResource:
     /// Build the INSERT statement consumed by the drainer when Redis is the
     /// write path.
     ///
-    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    /// The pooled connection is used to resolve bind type metadata (OIDs).
     async fn generate_insert_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         new_object: &Self::DieselNew,
     ) -> error_stack::Result<SerializableQuery, KvError>;
 
@@ -159,9 +159,9 @@ pub(crate) trait KvDeletableResource: KvResource {
     /// Build the DELETE statement consumed by the drainer when Redis is the
     /// delete path.
     ///
-    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    /// The pooled connection is used to resolve bind type metadata (OIDs).
     async fn generate_delete_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError>;
 
@@ -197,9 +197,9 @@ pub(crate) trait KvUpdatableResource: KvResource {
     /// Build the UPDATE statement consumed by the drainer when Redis is the
     /// update path.
     ///
-    /// A live pooled connection is used to resolve bind type metadata (OIDs).
+    /// The pooled connection is used to resolve bind type metadata (OIDs).
     async fn generate_update_drainer_query(
-        store: &Storage,
+        conn: &PgPooledConn,
         update: &Self::DieselUpdate,
         pk: &Self::PrimaryKeyType,
     ) -> error_stack::Result<SerializableQuery, KvError>;
@@ -377,6 +377,16 @@ where
     kv_backend_error::<E>(Report::new(KvError::DuplicateValue {
         key: key.to_string(),
     }))
+}
+
+/// Acquire a primary pool connection for drainer query generation, mapping
+/// pool-acquire failures into the KV error domain.
+async fn drainer_query_conn(store: &Storage) -> error_stack::Result<DbConnection<'_>, KvError> {
+    store.get_conn().await.map_err(|err| {
+        err.error
+            .change_context(KvError::Backend)
+            .attach_printable("failed to acquire database connection for drainer query generation")
+    })
 }
 
 fn kv_key_context(partition_key: &str, secondary_key: &str) -> String {
@@ -880,7 +890,10 @@ where
     match decided_scheme {
         DecidedStorageScheme::PostgresOnly => M::storage_insert(diesel_new, store).await,
         DecidedStorageScheme::Kv(kv_backend) => {
-            let drainer_query = M::generate_insert_drainer_query(store, &diesel_new)
+            let drainer_conn = drainer_query_conn(store)
+                .await
+                .map_err(kv_backend_error::<M::Error>)?;
+            let drainer_query = M::generate_insert_drainer_query(drainer_conn.get(), &diesel_new)
                 .await
                 .map_err(kv_backend_error::<M::Error>)?;
 
@@ -1151,9 +1164,13 @@ where
                 Some(resource) => resource,
                 None => find_resource_by_id_inner::<M>(store, primary_key.clone()).await?,
             };
-            let update_query = M::generate_update_drainer_query(store, &update, &primary_key)
+            let drainer_conn = drainer_query_conn(store)
                 .await
                 .map_err(kv_backend_error::<M::Error>)?;
+            let update_query =
+                M::generate_update_drainer_query(drainer_conn.get(), &update, &primary_key)
+                    .await
+                    .map_err(kv_backend_error::<M::Error>)?;
             let updated_model = M::apply_update(update, current);
             let updated_resource = updated_model.clone().into();
 
@@ -1198,7 +1215,10 @@ where
         DecidedStorageScheme::Kv(kv_backend) => {
             let partition_key = primary_key.get_partition_key();
             let secondary_key = primary_key.get_secondary_key();
-            let delete_query = M::generate_delete_drainer_query(store, &primary_key)
+            let drainer_conn = drainer_query_conn(store)
+                .await
+                .map_err(kv_backend_error::<M::Error>)?;
+            let delete_query = M::generate_delete_drainer_query(drainer_conn.get(), &primary_key)
                 .await
                 .map_err(kv_backend_error::<M::Error>)?;
 

--- a/src/storage/kv/serializable_query.rs
+++ b/src/storage/kv/serializable_query.rs
@@ -59,6 +59,7 @@ mod pg_type_metadata {
     }
 }
 
+use async_bb8_diesel::AsyncConnection;
 use diesel::{
     Insertable,
     associations::HasTable,
@@ -74,26 +75,9 @@ use hyperswitch_masking::Secret;
 use tracing::debug;
 
 use super::entity::EntityType;
-use crate::error::kv::KvError;
+use crate::{error::kv::KvError, storage::Storage};
 
 type SecretBinaryData = Secret<Vec<u8>>;
-
-// Offline query builder — no live `PgConnection` available, so `Pg` alone can't
-// satisfy `PgMetadataLookup`. This stub returns a dummy OID; the drainer replays
-// with a live connection that resolves real OIDs at execution time.
-const FAKE_OID: u32 = 0;
-
-struct KvPgMetadataLookup;
-
-impl diesel::pg::PgMetadataLookup for KvPgMetadataLookup {
-    fn lookup_type(
-        &mut self,
-        _type_name: &str,
-        _schema: Option<&str>,
-    ) -> diesel::pg::PgTypeMetadata {
-        diesel::pg::PgTypeMetadata::new(FAKE_OID, FAKE_OID)
-    }
-}
 
 /// SQL query and bind parameters in a serializable representation.
 #[derive(Debug, serde::Serialize, serde::Deserialize)]
@@ -134,7 +118,8 @@ impl SerializableQuery {
     }
 
     /// Construct a `SerializableQuery` from any diesel query fragment.
-    fn from_query<Q>(
+    async fn from_query<Q>(
+        store: &Storage,
         query: Q,
         entity_type: String,
         operation: DatabaseOperation,
@@ -158,10 +143,27 @@ impl SerializableQuery {
                 "Failed to determine whether query is safe to store in prepared statement cache",
             )?;
 
-        let mut bind_collector = RawBytesBindCollector::<Pg>::new();
-        let mut metadata_lookup = KvPgMetadataLookup;
-        query
-            .collect_binds(&mut bind_collector, &mut metadata_lookup, &Pg)
+        // Mirror hyperswitch's KV implementation: collect binds against a live
+        // pooled connection. `PgConnection` implements `diesel::pg::PgMetadataLookup`,
+        // so the recorded bind type metadata carries real OID information for the
+        // drainer to replay.
+        let conn = store
+            .get_conn()
+            .await
+            .map_err(|err| err.error)
+            .change_context(KvError::Backend)
+            .attach_printable(
+                "Failed to acquire database connection for drainer query generation",
+            )?;
+
+        let bind_collector = conn
+            .get()
+            .run(move |c| {
+                let mut bind_collector = RawBytesBindCollector::<Pg>::new();
+                query.collect_binds(&mut bind_collector, c, &Pg)?;
+                Ok::<RawBytesBindCollector<Pg>, diesel::result::Error>(bind_collector)
+            })
+            .await
             .change_context(KvError::SerializationFailed)
             .attach_printable("Failed to construct bind parameters")?;
 
@@ -200,7 +202,10 @@ impl SerializableQuery {
     }
 }
 
-pub(crate) fn generate_insert_query<T, N>(new: N) -> error_stack::Result<SerializableQuery, KvError>
+pub(crate) async fn generate_insert_query<T, N>(
+    store: &Storage,
+    new: N,
+) -> error_stack::Result<SerializableQuery, KvError>
 where
     T: HasTable<Table = T> + Table + Send + 'static,
     N: Insertable<T> + EntityType,
@@ -209,11 +214,13 @@ where
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
     let query = diesel::insert_into(<T as HasTable>::table()).values(new);
-    SerializableQuery::from_query(query, entity_type, DatabaseOperation::Insert)
+    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Insert)
+        .await
         .attach_printable("Failed to generate insert query")
 }
 
-pub(crate) fn generate_delete_query<Q, N>(
+pub(crate) async fn generate_delete_query<Q, N>(
+    store: &Storage,
     query: Q,
 ) -> error_stack::Result<SerializableQuery, KvError>
 where
@@ -221,11 +228,13 @@ where
     Q: QueryFragment<Pg> + Send + 'static,
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
-    SerializableQuery::from_query(query, entity_type, DatabaseOperation::Delete)
+    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Delete)
+        .await
         .attach_printable("Failed to generate delete query")
 }
 
-pub(crate) fn generate_update_query<Q, N>(
+pub(crate) async fn generate_update_query<Q, N>(
+    store: &Storage,
     query: Q,
 ) -> error_stack::Result<SerializableQuery, KvError>
 where
@@ -233,6 +242,7 @@ where
     Q: QueryFragment<Pg> + Send + 'static,
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
-    SerializableQuery::from_query(query, entity_type, DatabaseOperation::Update)
+    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Update)
+        .await
         .attach_printable("Failed to generate update query")
 }

--- a/src/storage/kv/serializable_query.rs
+++ b/src/storage/kv/serializable_query.rs
@@ -75,7 +75,7 @@ use hyperswitch_masking::Secret;
 use tracing::debug;
 
 use super::entity::EntityType;
-use crate::{error::kv::KvError, storage::Storage};
+use crate::{error::kv::KvError, storage::PgPooledConn};
 
 type SecretBinaryData = Secret<Vec<u8>>;
 
@@ -118,8 +118,13 @@ impl SerializableQuery {
     }
 
     /// Construct a `SerializableQuery` from any diesel query fragment.
+    ///
+    /// Mirror hyperswitch's KV implementation: binds are collected against the
+    /// live pooled connection. `PgConnection` implements
+    /// `diesel::pg::PgMetadataLookup`, so the recorded bind type metadata
+    /// carries real OID information for the drainer to replay.
     async fn from_query<Q>(
-        store: &Storage,
+        conn: &PgPooledConn,
         query: Q,
         entity_type: String,
         operation: DatabaseOperation,
@@ -143,21 +148,7 @@ impl SerializableQuery {
                 "Failed to determine whether query is safe to store in prepared statement cache",
             )?;
 
-        // Mirror hyperswitch's KV implementation: collect binds against a live
-        // pooled connection. `PgConnection` implements `diesel::pg::PgMetadataLookup`,
-        // so the recorded bind type metadata carries real OID information for the
-        // drainer to replay.
-        let conn = store
-            .get_conn()
-            .await
-            .map_err(|err| err.error)
-            .change_context(KvError::Backend)
-            .attach_printable(
-                "Failed to acquire database connection for drainer query generation",
-            )?;
-
         let bind_collector = conn
-            .get()
             .run(move |c| {
                 let mut bind_collector = RawBytesBindCollector::<Pg>::new();
                 query.collect_binds(&mut bind_collector, c, &Pg)?;
@@ -203,7 +194,7 @@ impl SerializableQuery {
 }
 
 pub(crate) async fn generate_insert_query<T, N>(
-    store: &Storage,
+    conn: &PgPooledConn,
     new: N,
 ) -> error_stack::Result<SerializableQuery, KvError>
 where
@@ -214,13 +205,13 @@ where
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
     let query = diesel::insert_into(<T as HasTable>::table()).values(new);
-    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Insert)
+    SerializableQuery::from_query(conn, query, entity_type, DatabaseOperation::Insert)
         .await
         .attach_printable("Failed to generate insert query")
 }
 
 pub(crate) async fn generate_delete_query<Q, N>(
-    store: &Storage,
+    conn: &PgPooledConn,
     query: Q,
 ) -> error_stack::Result<SerializableQuery, KvError>
 where
@@ -228,13 +219,13 @@ where
     Q: QueryFragment<Pg> + Send + 'static,
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
-    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Delete)
+    SerializableQuery::from_query(conn, query, entity_type, DatabaseOperation::Delete)
         .await
         .attach_printable("Failed to generate delete query")
 }
 
 pub(crate) async fn generate_update_query<Q, N>(
-    store: &Storage,
+    conn: &PgPooledConn,
     query: Q,
 ) -> error_stack::Result<SerializableQuery, KvError>
 where
@@ -242,7 +233,7 @@ where
     Q: QueryFragment<Pg> + Send + 'static,
 {
     let entity_type = N::ENTITY_TYPE.to_owned();
-    SerializableQuery::from_query(store, query, entity_type, DatabaseOperation::Update)
+    SerializableQuery::from_query(conn, query, entity_type, DatabaseOperation::Update)
         .await
         .attach_printable("Failed to generate update query")
 }


### PR DESCRIPTION
## Summary

Removes the offline `KvPgMetadataLookup` stub (which returned `FAKE_OID = 0` for every bind type) and adopts the hyperswitch KV approach: `collect_binds` now runs against a **live pooled `PgConnection`**, which implements diesel's `PgMetadataLookup`. The serialized drainer query therefore carries real bind type metadata (OIDs) for the drainer to replay, matching `diesel_models/src/kv.rs`.

## Changes

- `serializable_query.rs`: drop `FAKE_OID`/`KvPgMetadataLookup`; `from_query` is now async, takes `&Storage`, acquires a primary pool connection, and collects binds via `conn.get().run(move |c| query.collect_binds(&mut bc, c, &Pg))`. Pool acquisition failure maps to `KvError::Backend`.
- `generate_{insert,update,delete}_query`: now async, take `&Storage`.
- `resource.rs`: `generate_{insert,update,delete}_drainer_query` trait methods are now async with a `store: &Storage` first parameter; call sites updated with `store` + `.await`.
- All five table impls (`vault`, `locker`, `reverse_lookup`, `fingerprint`, `hash_table`) updated to the new async signatures.

## Verification

- `cargo check --features kv` passes
- `cargo clippy --features kv` passes with no warnings
- No references to `FAKE_OID` / `KvPgMetadataLookup` remain

Stacked on `chore/migrate-diesel-async-bb8-diesel`.